### PR TITLE
Improve code to trigger repo dispatch

### DIFF
--- a/docs/Deploy/discover-environment.md
+++ b/docs/Deploy/discover-environment.md
@@ -10,15 +10,16 @@ In a terminal, type the following commands by replacing the placeholders (<...>)
 
 **PowerShell:**
 ```powershell
-$username = "codertocat"
-$password = "<PAT_TOKEN>"
-$uri = "https://api.github.com/repos/<Your GitHub ID>/<Your Repo Name>/dispatches"
+$GitHubUserName = "<GH UserName>"
+$GitHubPAT = "<PAT TOKEN>"
+$GitHubRepoName = "<Repo Name>"
+$uri = "https://api.github.com/repos/$GitHubUserName/$GitHubRepoName/dispatches"
 $params = @{
     Uri = $uri
     Headers = @{
         "Accept" = "application/vnd.github.everest-preview+json"
         "Content-Type" = "application/json"
-        "Authorization" = "Basic $([Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $username,$password))))"
+        "Authorization" = "Basic $([Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $GitHubUserName,$GitHubPAT))))"
         }
     Body = @{
         "event_type" = "activity-logs"
@@ -29,7 +30,7 @@ Invoke-RestMethod -Method "POST" @params
 
 **Bash:**
 ```bash
-curl -u "Codertocat:<PAT Token>" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/<Your GitHub ID>/<Your Repo Name>/dispatches --data '{"event_type": "activity-logs"}'
+curl -u "<GH UserName>:<PAT Token>" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/<Your GitHub ID>/<Your Repo Name>/dispatches --data '{"event_type": "activity-logs"}'
 ```
 
 Please check progress in the GitHub repo in the Actions tab and wait for it complete. At present, if your environment contains management group or subscription with duplicate display name, initialization of discovery will fail. This is precautionary check to avoid accidental misconfiguration and we highly recommend unique names for management groups and subscriptions. There is work planned to override Display Name with Name ETA 7/31.


### PR DESCRIPTION
**This PR improves documentation**

* Improve the PoSH code to declare the variables required at the start.
* Parameterise the URI to avoid repetition
* Change username from codertocat to something that indicates it must be changed by the user

fixes Azure/Azure-Landing-Zones#3407 

