### PR TITLE
updating instruction to include organisation name

### DIFF
--- a/docs/Deploy/discover-environment.md
+++ b/docs/Deploy/discover-environment.md
@@ -11,7 +11,7 @@ In a terminal, type the following commands by replacing the placeholders (<...>)
 
 **PowerShell:**
 ```powershell
-$GitHubUserName = "<GH UserName>"
+$GitHubUserName = "<GH UserName or Github Enterprise Organisation Name>"
 $GitHubPAT = "<PAT TOKEN>"
 $GitHubRepoName = "<Repo Name>"
 $uri = "https://api.github.com/repos/$GitHubUserName/$GitHubRepoName/dispatches"


### PR DESCRIPTION
If a user is using Github Enterprise, you need to refer to the Organisation Name rather than their personal github username. The current code assumes the user has forked the Repo into their personal account.

<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**