### PR TITLE
Fix for AKS diagnostics settings

### DIFF
--- a/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560/contoso/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-AKS.parameters.json
+++ b/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560/contoso/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-AKS.parameters.json
@@ -90,7 +90,7 @@
                             ],
                             "logs": [
                               {
-                                "category": "guard",
+                                "category": "kube-audit",
                                 "enabled": true
                               },
                               {


### PR DESCRIPTION
This pull request fixes the issue with the diagnostics settings for AKS.

"Guard" is not a diagnostic setting and appears to be a typo for kube-audit

![image](https://user-images.githubusercontent.com/64849879/85386908-139ddf00-b53c-11ea-9666-dac6724d9485.png)
