### PR TITLE
Added missing log categories for Cosmos DB

### DIFF
--- a/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-CosmosDB.parameters.json
+++ b/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-CosmosDB.parameters.json
@@ -100,6 +100,26 @@
                               {
                                 "category": "QueryRuntimeStatistics",
                                 "enabled": true
+                              },
+                              {
+                                "category": "PartitionKeyStatistics",
+                                "enabled": true
+                              },
+                              {
+                                "category": "PartitionKeyRUConsumption",
+                                "enabled": true
+                              },
+                              {
+                                "category": "ControlPlaneRequests",
+                                "enabled": true
+                              },
+                              {
+                                "category": "CassandraRequests",
+                                "enabled": true
+                              },
+                              {
+                                "category": "GremlinRequests",
+                                "enabled": true
                               }
                             ]
                           }


### PR DESCRIPTION
Missing log categories for Cosmos DB lead to a non-compliant policy. Added missing categories, so that the policy can reach a compliant state

<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
This PR fixes https://github.com/Azure/Enterprise-Scale/issues/137 .