### PR TITLE
Added missing log categories for SQLDB

### DIFF
--- a/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-SQLDBs.parameters.json
+++ b/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-SQLDBs.parameters.json
@@ -126,6 +126,10 @@
                                 "enabled": true
                               },
                               {
+                                "category": "DevOpsOperationsAudit",
+                                "enabled": true
+                              },
+                              {
                                 "category": "SQLSecurityAuditEvents",
                                 "enabled": true
                               }


### PR DESCRIPTION
Missing log categories for SQL DB lead to a non-compliant policy. Added missing categories, so that the policy can reach a compliant state

<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
This PR fixes https://github.com/Azure/Enterprise-Scale/issues/136