### PR TITLE
Deploy-Diagnostics-RecoveryVault fix for notEquals

### DIFF
--- a/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-RecoveryVault.parameters.json
+++ b/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-Diagnostics-RecoveryVault.parameters.json
@@ -60,7 +60,7 @@
                     },
                     {
                       "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
-                      "notEquals": "[parameters('logAnalytics')]"
+                      "equals": "[parameters('logAnalytics')]"
                     },
                     {
                       "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",

--- a/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Management_managementGroups-contoso.parameters.json
+++ b/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Management_managementGroups-contoso.parameters.json
@@ -5677,7 +5677,7 @@
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
-                            "notEquals": "[parameters('logAnalytics')]"
+                            "equals": "[parameters('logAnalytics')]"
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",

--- a/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
+++ b/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
@@ -5062,7 +5062,7 @@
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
-                            "notEquals": "[[parameters('logAnalytics')]"
+                            "equals": "[[parameters('logAnalytics')]"
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",

--- a/docs/reference/contoso/armTemplates/auxiliary/policies.json
+++ b/docs/reference/contoso/armTemplates/auxiliary/policies.json
@@ -5062,7 +5062,7 @@
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
-                            "notEquals": "[[parameters('logAnalytics')]"
+                            "equals": "[[parameters('logAnalytics')]"
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",

--- a/docs/reference/wingtip/armTemplates/auxiliary/policies.json
+++ b/docs/reference/wingtip/armTemplates/auxiliary/policies.json
@@ -5062,7 +5062,7 @@
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
-                            "notEquals": "[[parameters('logAnalytics')]"
+                            "equals": "[[parameters('logAnalytics')]"
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
https://github.com/Azure/Enterprise-Scale/issues/214

The policy Deploy-Diagnostics-RecoveryVault always show none compliant because of "existenceCondition" check
"notEquals": "[parameters('logAnalytics')]" should be "equels"