### PR TITLE
Process organization

### DIFF
--- a/docs/Deploy/getting-started.md
+++ b/docs/Deploy/getting-started.md
@@ -40,4 +40,4 @@ Minimum version of PowerShell: 7.0|  The latest version of PowerShell including 
 
 ## Next steps
 
-Once you have the technical prerequisites in place, you can proceed to the next step, [Configure Azure permissions for ARM tenant deployments & setup GitHub](./setup-github.md).
+Once you have the technical prerequisites in place, you can proceed to the next step, lets go back to [Introduction to Enterprise-Scale "in-a-box"](https://github.com/Azure/Enterprise-Scale/blob/main/docs/enterprise-scale-iab/README.md) and [deploy your Enterprise-scale Tenant](https://github.com/Azure/Enterprise-Scale/blob/main/docs/enterprise-scale-iab/deploy-tenant.md).


### PR DESCRIPTION
At the end of the prerequires we should go back to the introduction or deploy a tenant vs jumping to the github setup the second phase of ES in-a-box. Feedback from proctors running through the workshop. 

<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**