### PR TITLE
Remove discovery root environment variable from ADO pipeline

### DIFF
--- a/.azure-pipelines/azops-pull.yml
+++ b/.azure-pipelines/azops-pull.yml
@@ -27,7 +27,6 @@ variables:
   AZOPS_STRICT_MODE: 0
   AZOPS_THROTTLE_LIMIT: 10
   AZOPS_SUPPORT_PARTIAL_MG_DISCOVERY: 0
-  AZOPS_PARTIAL_MG_DISCOVERY_ROOT: ""
   AZDEVOPS_USERNAME: AzOps
   AZDEVOPS_EMAIL: noreply@azure.com
   AZDEVOPS_PULL_REQUEST: "Azure Change Notification"
@@ -76,7 +75,6 @@ jobs:
               --env AZOPS_STRICT_MODE \
               --env AZOPS_THROTTLE_LIMIT \
               --env AZOPS_SUPPORT_PARTIAL_MG_DISCOVERY \
-              --env AZOPS_PARTIAL_MG_DISCOVERY_ROOT \
               --env AZDEVOPS_USERNAME \
               --env AZDEVOPS_EMAIL \
               --env AZDEVOPS_PULL_REQUEST \

--- a/.azure-pipelines/azops-push.yml
+++ b/.azure-pipelines/azops-push.yml
@@ -19,7 +19,6 @@ variables:
   AZOPS_STRICT_MODE: 0
   AZOPS_THROTTLE_LIMIT: 10
   AZOPS_SUPPORT_PARTIAL_MG_DISCOVERY: 0
-  AZOPS_PARTIAL_MG_DISCOVERY_ROOT: ""
   AZDEVOPS_USERNAME: AzOps
   AZDEVOPS_EMAIL: noreply@azure.com
   AZDEVOPS_PULL_REQUEST: "Azure Change Notification"
@@ -68,7 +67,6 @@ jobs:
               --env AZOPS_STRICT_MODE \
               --env AZOPS_THROTTLE_LIMIT \
               --env AZOPS_SUPPORT_PARTIAL_MG_DISCOVERY \
-              --env AZOPS_PARTIAL_MG_DISCOVERY_ROOT \
               --env AZDEVOPS_USERNAME \
               --env AZDEVOPS_EMAIL \
               --env AZDEVOPS_PULL_REQUEST \


### PR DESCRIPTION
Discovery happends depending an access permission.