### PR TITLE
fix Deploy-Diagnostics-iotHub.

### DIFF
--- a/docs/reference/wingtip/armTemplates/auxiliary/policies.json
+++ b/docs/reference/wingtip/armTemplates/auxiliary/policies.json
@@ -3728,11 +3728,15 @@
                                       "enabled": true
                                     },
                                     {
-                                      "category": "E2EDiagnostics",
+                                      "category": "DistributedTracing",
                                       "enabled": true
                                     },
                                     {
                                       "category": "Configurations",
+                                      "enabled": true
+                                    },
+                                    {
+                                      "category": "DeviceStreams",
                                       "enabled": true
                                     }
                                   ]


### PR DESCRIPTION
This PR fixes the policy Deploy-Diagnostics-iotHub,  "E2EDiagnostics" category doesn't exists.