### PR TITLE
Fix recovery service vault compliance logic

### DIFF
--- a/docs/reference/contoso/armTemplates/auxiliary/policies.json
+++ b/docs/reference/contoso/armTemplates/auxiliary/policies.json
@@ -5066,7 +5066,7 @@
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
-                            "notEquals": "[[parameters('logAnalytics')]"
+                            "equals": "[[parameters('logAnalytics')]"
                           },
                           {
                             "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",


### PR DESCRIPTION
**This PR fixes** notEquals should be equals. Its validating the correct log analytics workspace  is is configured against the vault for which the policy expects. Without the fix it will always flag a compliance issue when configured correctly
