### PR TITLE
adding scope-escape to LZ create experience

### DIFF
--- a/docs/EnterpriseScale-Deploy-landing-zones.md
+++ b/docs/EnterpriseScale-Deploy-landing-zones.md
@@ -31,8 +31,9 @@ The following deployment experiences can be leveraged to create multiple landing
 
 This [document](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/programmatically-create-subscription?tabs=rest-getEnrollments%2Crest-EA%2Crest-getBillingAccounts%2Crest-getBillingProfiles%2Crest-MCA%2Crest-getBillingAccount-MPA%2Crest-getCustomers%2Crest-getIndirectResellers%2Crest-MPA) outlines the requirements depending on the agreement type you have, and the RBAC permissions needed.
 
+To deploy the ARM templates below to create new subscriptions, you must have Management Group Contributor or Owner permission on the Management Group where you will invoke the deployment and the targeted Management Groups for the new subscriptions.
+
 | Agreement types | ARM Template |
 |:-------------------------|:-------------|
 | Enterprise Agreement (EA) |[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2Fmain%2Fdocs%2Freference%2Flzs%2FarmTemplates%2Feslz.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2Fmain%2Fdocs%2Freference%2Flzs%2FarmTemplates%2Fportal-eslz.json)
 | Microsoft Customer Agreement  | Coming soon
-| Microsoft Partner Agreement | Coming soon

--- a/docs/reference/lzs/armTemplates/eslz.json
+++ b/docs/reference/lzs/armTemplates/eslz.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "subscriptions": {
@@ -14,12 +14,12 @@
     "resources": [
         {
             // Routing the request to the tenant root to PUT subscriptions
-           // "scope": "/", //commenting out this property as it is not available in all regions yet. Once available, you can deploy this as management group deployment instead of tenant deployment
+            "scope": "/",
             "name": "[concat(parameters('subscriptions')[copyIndex()].esSubName)]",
             "type": "Microsoft.Subscription/aliases",
             "apiVersion": "2020-09-01",
             "copy": {
-                "name": "subAliasCopy",
+                "name": "eslzSubCopy",
                 "count": "[length(parameters('subscriptions'))]"
             },
             "properties": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
* Invokes the deployment at management group scope, and will use "scope" property to route the subscription creation request to the tenant root (/).
* Does no longer require permissions at the tenant root scope for creating subscriptions