### PR TITLE
add information about authentication in to azure subscription

### DIFF
--- a/docs/EnterpriseScale-Setup-azure.md
+++ b/docs/EnterpriseScale-Setup-azure.md
@@ -36,6 +36,15 @@ az role assignment create  --scope '/' --role 'Owner' --assignee-object-id $(az 
 PowerShell
 
 ````powershell
+#sign in to azure from Powershell (NOTE: no need to have AzureAD module to use AzAD commands as they are part of Az.Resource module). In powershell 7.x you will be redirected to webbrowser for authentication, if required
+Connect-AzAccount
+
+#check if you have proper subscription selected and select the right one if required
+Get-AzSubscription | Select-Object SubscriptionId, Name
+
+#select right and replace SubscriptionId result of previous
+Select-AzSubscription '<SubscriptionId>'
+
 #get object Id of the user
 $user = Get-AzADUser -UserPrincipalName '<replace-me>@<my-aad-domain.com>'
 


### PR DESCRIPTION
advanced user probably don't think about it, but as i was going through documentation I found reference only to powershell modules Az.Resource and Az.Accounts. No details how to sign in/authenticate/select subscription. I think it should be referenced in some pages. 
Added info about following commandlets Connect-AzAccount, Get-AzSubscription, Select-AzSubscription

<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**