### PR TITLE
add pricingTierSQLVMs to deploy-asc-standard

### DIFF
--- a/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-ASC-Standard.parameters.json
+++ b/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560 (3fc1081d-6105-4e19-b60c-1ec1252cf560)/contoso (contoso)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-ASC-Standard.parameters.json
@@ -97,6 +97,17 @@
               "defaultValue": "Standard"
             }
           },
+          "pricingTierSQLVMs":{
+            "type": "String",
+            "metadata": {
+                "displayName": "pricingTierSQLVMs"
+            },
+            "allowedValues": [
+              "Standard",
+              "Free"
+            ],
+            "defaultValue": "Standard"
+        },
           "PolicyRule": {
             "if": {
               "allOf": [
@@ -152,6 +163,9 @@
                       },
                       "pricingTierKubernetesService": {
                         "value": "[parameters('pricingTierKubernetesService')]"
+                      },
+                      "pricingTierSQLVMs": {
+                        "value": "[parameters('pricingTierSQLVMs')]"
                       }
                     },
                     "template": {
@@ -198,6 +212,12 @@
                           "type": "string",
                           "metadata": {
                             "description": "KubernetesService"
+                          }
+                        },
+                        "pricingTierSQLVMs": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "pricingTierSQLVMs"
                           }
                         }
                       },
@@ -275,6 +295,17 @@
                           ],
                           "properties": {
                             "pricingTier": "[parameters('pricingTierContainerRegistry')]"
+                          }
+                        },
+                        {
+                          "type": "Microsoft.Security/pricings",
+                          "apiVersion": "2018-06-01",
+                          "name": "SqlServerVirtualMachines",
+                          "dependsOn": [
+                            "[concat('Microsoft.Security/pricings/ContainerRegistry')]"
+                          ],
+                          "properties": {
+                            "pricingTier": "[parameters('pricingTierSQLVMs')]"
                           }
                         }
                       ],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->
![sqlonvms](https://user-images.githubusercontent.com/34237608/100434071-dcf06580-3093-11eb-9fe8-ad152f43c19d.JPG)


**This PR fixes**
fixes #334
This PR adds a setting to the Deploy-ASC-Standard definition which ensures that 'SQL servers on machines' is turned on as part of the Azure Security Center plan.  Image attached shows this setting as it appears in 'Azure Defender plans' in the portal.