### PR TITLE
Update policies.json

### DIFF
--- a/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
+++ b/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
@@ -9839,7 +9839,7 @@
               "then": {
                 "effect": "[[parameters('effect')]",
                 "details": {
-                  "type": "Microsoft.Network/networkWatchers/flowLogs",
+                  "type": "Microsoft.Network/networkWatchers/flowlogs",
                   "roleDefinitionIds": [
                     "/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
                     "/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293"


### PR DESCRIPTION
There is an issue with policy evaluation. Built-in policy has it in lowercase and it works I have replicated this change in Scale Enterprise definition in my environment and it works.

Change Microsoft.Network/networkWatchers/flowLogs to Microsoft.Network/networkWatchers/flowlogs. To fix policy evaluation