### PR TITLE
Ensure Service Principal assigned to Directory Reader

### DIFF
--- a/docs/Deploy/setup-azuredevops.md
+++ b/docs/Deploy/setup-azuredevops.md
@@ -3,6 +3,7 @@
 Please complete the following steps at [Configure Azure permissions for ARM tenant deployments](setup-github.md) page before continuing:
 
 * Step 3 - Create SPN and Grant Permission
+* Step 4 - Grant Azure Active Directory permissions for SPN
 * Step 5 - Configure your repo to update changes from upstream
 
 ## Implementation notes


### PR DESCRIPTION
Included reference to adding Directory Reader role to AzOps SPN.

Without this step, AzOps Pull will not be able to retrieve role definitions & assignments and will skip over with warning

```
(Initialize-AzOpsRepository) Missing Directory.Read permissions in Azure AD Graph. Skipping discovery of RoleAssignments and RoleDefinitions
``` 