### PR TITLE
Fix character casing for "type": "String"

### DIFF
--- a/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
+++ b/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
@@ -1132,11 +1132,11 @@
                                         "contentVersion": "1.0.0.0",
                                         "parameters": {
                                           "remoteVirtualNetwork": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           },
                                           "hubName": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           }
                                         },

--- a/docs/reference/contoso/armTemplates/auxiliary/policies.json
+++ b/docs/reference/contoso/armTemplates/auxiliary/policies.json
@@ -1132,11 +1132,11 @@
                                         "contentVersion": "1.0.0.0",
                                         "parameters": {
                                           "remoteVirtualNetwork": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           },
                                           "hubName": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           }
                                         },

--- a/docs/reference/treyresearch/armTemplates/auxiliary/policies.json
+++ b/docs/reference/treyresearch/armTemplates/auxiliary/policies.json
@@ -1132,11 +1132,11 @@
                                         "contentVersion": "1.0.0.0",
                                         "parameters": {
                                           "remoteVirtualNetwork": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           },
                                           "hubName": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           }
                                         },

--- a/docs/reference/wingtip/armTemplates/auxiliary/policies.json
+++ b/docs/reference/wingtip/armTemplates/auxiliary/policies.json
@@ -1132,11 +1132,11 @@
                                         "contentVersion": "1.0.0.0",
                                         "parameters": {
                                           "remoteVirtualNetwork": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           },
                                           "hubName": {
-                                            "type": "string",
+                                            "type": "String",
                                             "defaultValue": false
                                           }
                                         },


### PR DESCRIPTION
This PR updates a missing fix for character casing where `"type": "string"` should be `"type": "String"`