### PR TITLE
Consistent Policy Name Casing

### DIFF
--- a/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
+++ b/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
@@ -16590,7 +16590,7 @@
               }
             }
           },
-          "name": "Deploy-Diagnostics-DataExplorerCLuster"
+          "name": "Deploy-Diagnostics-DataExplorerCluster"
         },
         {
           "properties": {
@@ -19140,7 +19140,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCLuster')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCluster')]",
                 "policyDefinitionReferenceId": "DataExplorerClusterDeployDiagnosticLogDeployLogAnalytics",
                 "parameters": {
                   "logAnalytics": {
@@ -20946,7 +20946,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSql-sslEnforcement')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement')]",
                 "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect",
                 "parameters": {
                   "effect": {

--- a/docs/reference/contoso/armTemplates/auxiliary/policies.json
+++ b/docs/reference/contoso/armTemplates/auxiliary/policies.json
@@ -16590,7 +16590,7 @@
               }
             }
           },
-          "name": "Deploy-Diagnostics-DataExplorerCLuster"
+          "name": "Deploy-Diagnostics-DataExplorerCluster"
         },
         {
           "properties": {
@@ -19140,7 +19140,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCLuster')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCluster')]",
                 "policyDefinitionReferenceId": "DataExplorerClusterDeployDiagnosticLogDeployLogAnalytics",
                 "parameters": {
                   "logAnalytics": {
@@ -20946,7 +20946,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSql-sslEnforcement')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement')]",
                 "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect",
                 "parameters": {
                   "effect": {

--- a/docs/reference/treyresearch/armTemplates/auxiliary/policies.json
+++ b/docs/reference/treyresearch/armTemplates/auxiliary/policies.json
@@ -16590,7 +16590,7 @@
               }
             }
           },
-          "name": "Deploy-Diagnostics-DataExplorerCLuster"
+          "name": "Deploy-Diagnostics-DataExplorerCluster"
         },
         {
           "properties": {
@@ -19140,7 +19140,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCLuster')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCluster')]",
                 "policyDefinitionReferenceId": "DataExplorerClusterDeployDiagnosticLogDeployLogAnalytics",
                 "parameters": {
                   "logAnalytics": {
@@ -20946,7 +20946,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSql-sslEnforcement')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement')]",
                 "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect",
                 "parameters": {
                   "effect": {

--- a/docs/reference/wingtip/armTemplates/auxiliary/policies.json
+++ b/docs/reference/wingtip/armTemplates/auxiliary/policies.json
@@ -16590,7 +16590,7 @@
               }
             }
           },
-          "name": "Deploy-Diagnostics-DataExplorerCLuster"
+          "name": "Deploy-Diagnostics-DataExplorerCluster"
         },
         {
           "properties": {
@@ -19140,7 +19140,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCLuster')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCluster')]",
                 "policyDefinitionReferenceId": "DataExplorerClusterDeployDiagnosticLogDeployLogAnalytics",
                 "parameters": {
                   "logAnalytics": {
@@ -20946,7 +20946,7 @@
                 }
               },
               {
-                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSql-sslEnforcement')]",
+                "policyDefinitionId": "[concat(variables('scope'), '/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement')]",
                 "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect",
                 "parameters": {
                   "effect": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

This PR updates the policy name for `Deploy-Diagnostics-DataExplorerCluster` to ensure correct use of `PascalCasing`.

It also udpates the reference to Policy Definition `Deploy-PostgreSQL-sslEnforcement` in Policy Set Definition `Deploy-Diag-LogAnalytics` to match the casing used in the Policy Definition.

These changes, whilst cosmetic in ARM, are necessary to ensure consistent processing in the [Terraform Module for Cloud Adoption Framework Enterprise-scale](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale) and were highlighted as part of the latest [Update Library Templates](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pull/66) action.