### PR TITLE
Update policy mode Indexed->All for TLS version

### DIFF
--- a/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
+++ b/docs/reference/adventureworks/armTemplates/auxiliary/policies.json
@@ -16979,7 +16979,7 @@
         {
           "properties": {
             "displayName": "AppService append sites with minimum TLS version to enforce.",
-            "mode": "Indexed",
+            "mode": "All",
             "description": "Append the AppService sites object to ensure that min Tls version is set to required minimum TLS version. Please note Append does not enforce compliance use then deny.",
             "metadata": {
               "version": "1.0.0",

--- a/docs/reference/contoso/armTemplates/auxiliary/policies.json
+++ b/docs/reference/contoso/armTemplates/auxiliary/policies.json
@@ -16979,7 +16979,7 @@
         {
           "properties": {
             "displayName": "AppService append sites with minimum TLS version to enforce.",
-            "mode": "Indexed",
+            "mode": "All",
             "description": "Append the AppService sites object to ensure that min Tls version is set to required minimum TLS version. Please note Append does not enforce compliance use then deny.",
             "metadata": {
               "version": "1.0.0",

--- a/docs/reference/treyresearch/armTemplates/auxiliary/policies.json
+++ b/docs/reference/treyresearch/armTemplates/auxiliary/policies.json
@@ -15999,7 +15999,7 @@
         {
           "properties": {
             "displayName": "AppService append sites with minimum TLS version to enforce.",
-            "mode": "Indexed",
+            "mode": "All",
             "description": "Append the AppService sites object to ensure that min Tls version is set to required minimum TLS version. Please note Append does not enforce compliance use then deny.",
             "metadata": {
               "version": "1.0.0",

--- a/docs/reference/wingtip/armTemplates/auxiliary/policies.json
+++ b/docs/reference/wingtip/armTemplates/auxiliary/policies.json
@@ -16979,7 +16979,7 @@
         {
           "properties": {
             "displayName": "AppService append sites with minimum TLS version to enforce.",
-            "mode": "Indexed",
+            "mode": "All",
             "description": "Append the AppService sites object to ensure that min Tls version is set to required minimum TLS version. Please note Append does not enforce compliance use then deny.",
             "metadata": {
               "version": "1.0.0",


### PR DESCRIPTION
I could not get the policy Append-AppService-latestTLS to have any effect. I got help from Johan Dahlbom and it turned out that mode needs to be set to All for this one. I have tested on local version and with this fix the policy works. 