### PR TITLE
corrected -subscriptionId parameter for online connected landing zone…

### DIFF
--- a/eslzArm/README.md
+++ b/eslzArm/README.md
@@ -373,7 +373,7 @@ New-AzManagementGroupDeployment -Name "$($DeploymentName)-corp1" `
                                 -subscriptionId $CorpConnectedLandingZoneSubscriptionId `
                                 -Verbose                                
 
-# Add the first online connected landing zone subscription to Corp management group
+# Add the first online connected landing zone subscription to Online management group
 
 New-AzManagementGroupDeployment -Name "$($DeploymentName)-online1" `
                                 -ManagementGroupId "$($ESLZPrefix)-online" `

--- a/eslzArm/README.md
+++ b/eslzArm/README.md
@@ -380,6 +380,6 @@ New-AzManagementGroupDeployment -Name "$($DeploymentName)-online1" `
                                 -Location $Location `
                                 -TemplateFile .\eslzArm\managementGroupTemplates\subscriptionOrganization\subscriptionOrganization.json `
                                 -targetManagementGroupId "$($ESLZPrefix)-online" `
-                                -subscriptionId $CorpConnectedLandingZoneSubscriptionId `
+                                -subscriptionId $OnlineLandingZoneSubscriptionId `
                                 -Verbose                                                                
 ````


### PR DESCRIPTION
… subscription to $OnlineLandingZoneSubscriptionId

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Documentation update. Fixed the -subscriptionId parameter with the right environment variable $OnlineLandingZoneSubscriptionId for the online connected landing zone subscription

## This PR fixes/adds/changes/removes

1. Updated $OnlineLandingZoneSubscriptionId env variable

### Breaking Changes

None

## Testing Evidence

N/A. If a person runs that last deployment step, it would replace the online management group scope with the subscription designated as the corp landing zone .

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
