### PR TITLE
Update filter for "disabled" subscription state

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -44,6 +44,7 @@ Here's what's changed in Enterprise Scale:
 - [Terraform Module for Cloud Adoption Framework Enterprise-scale release v0.4.0](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/releases/tag/v0.4.0)
   - Brings support for Hub Connectivity & Identity landing zone peering - read more in the release notes linked above
 - [Do-It-Yourself deployment instructions for Enterprise-Scale using Azure PowerShell released](https://github.com/Azure/Enterprise-Scale/tree/main/eslzArm)
+- Update subscription filter in reference implementation UI experience. Subscriptions with state != "Enabled" will be excluded from the list of available subscriptions.
 
 #### Policy
 

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -1733,7 +1733,7 @@
                             "multiLine": true,
                             "visible": "[or(or(equals(steps('lzGoalState').esLzConnectivity, 'No'), equals(steps('esConnectivityGoalState').esHub, 'No')), equals(steps('esConnectivityGoalState').esHub, 'vwan'), equals(steps('lzGoalState').esLzConnectivity, 'No'))]",
                             "constraints": {
-                                "allowedValues": "[map(steps('lzGoalState').lzCorpSubsApi.value, (sub) => parse(concat('{\"label\":\"', sub.displayName, '\",\"description\":\"', sub.subscriptionId, '\",\"value\":\"', toLower(sub.subscriptionId), '\"}')) )]",
+                                "allowedValues": "[map(filter(steps('lzGoalState').lzCorpSubsApi.value, (sub) => equals(sub.state, 'Enabled')), (sub) => parse(concat('{\"label\":\"', sub.displayName, '\",\"description\":\"', sub.subscriptionId, '\",\"value\":\"', toLower(sub.subscriptionId), '\"}')) )]",
                                 "required": false
                             }
                         },
@@ -1832,7 +1832,7 @@
                             "multiLine": true,
                             "visible": true,
                             "constraints": {
-                                "allowedValues": "[map(steps('lzGoalState').lzOnlineSubsApi.value,(sub) => parse(concat('{\"label\":\"',sub.displayName,'\",\"description\":\"',sub.subscriptionId,'\",\"value\":\"',toLower(sub.subscriptionId),'\"}')))]",
+                                "allowedValues": "[map(filter(steps('lzGoalState').lzOnlineSubsApi.value, (sub) => equals(sub.state, 'Enabled')), (sub) => parse(concat('{\"label\":\"',sub.displayName,'\",\"description\":\"',sub.subscriptionId,'\",\"value\":\"',toLower(sub.subscriptionId),'\"}')))]",
                                 "required": false
                             }
                         },


### PR DESCRIPTION
## Overview/Summary

In the UI experience for the reference implementation subscription with state != Enabled are excluded.

## This PR fixes/adds/changes/removes

1. Excludes Subscriptions (state != Enabled from LZ filter for connected and online LZ

## Testing Evidence

Testing has been performed in my own tenant with 3 subscriptions one of them "disabled".

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [X] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
