### PR TITLE
Add September to TOC and typo for AzOps version number

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -2,6 +2,7 @@
 
 - [In this Section](#in-this-section)
 - [Updates](#updates)
+  - [September 2021](#september-2021)
   - [August 2021](#august-2021)
   - [July 2021](#july-2021)
   - [June 2021](#june-2021)
@@ -39,7 +40,7 @@ Here's what's changed in Enterprise Scale:
 #### Tooling
 
 - Added Option to select Azure Firewall SKU (https://github.com/Azure/Enterprise-Scale/pull/793)
-- [AzOps release v1.4.0](https://github.com/Azure/AzOps/releases/tag/1.5.0)
+- [AzOps release v1.5.0](https://github.com/Azure/AzOps/releases/tag/1.5.0)
 
 ### Policy
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Adds September 2021 to the Wiki "What's New?" TOC and fixes the AzOps version number typo

## This PR fixes/adds/changes/removes

1. Adds September 2021 to the Wiki "What's New?" TOC and fixes the AzOps version number typo (V1.4.0 instead of V1.5.0)

### Breaking Changes

None

## Testing Evidence

This is a Wiki page change which is valid markdown and can be tested by visiting it in the branch here: https://github.com/Azure/Enterprise-Scale/blob/jtracey93-patch-1/docs/wiki/Whats-new.md#september-2021

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
