### PR TITLE
Changed casings for parameter: pricingTierVMs

### DIFF
--- a/eslzArm/managementGroupTemplates/policyAssignments/DINE-ASCConfigPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DINE-ASCConfigPolicyAssignment.json
@@ -150,7 +150,7 @@
                     "ascExportResourceGroupLocation": {
                         "value": "[deployment().location]"
                     },
-                    "pricingTierVms": {
+                    "pricingTierVMs": {
                         "value": "[parameters('enableAscForServers')]"
                     },
                     "pricingTierSqlServers": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Change casing for `pricingTierVMs` parameter for ASC Policy Assignment at top level

## This PR fixes/adds/changes/removes

Fixes: Azure/Azure-Landing-Zones#3142 (Pricing Tier for VMs parameter in Policy Assignment )

### Breaking Changes

1. Nope

## Testing Evidence
Deployed the new template with the changes:
![image](https://user-images.githubusercontent.com/15022172/138259018-6b34605a-ba1e-4ce3-8c0f-8d8e70938ce6.png)

## As part of this Pull Request I have


- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
