### PR TITLE
Mooncake updates

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -33,6 +33,21 @@ This article will be updated as and when changes are made to the above and anyth
 
 Here's what's changed in Enterprise Scale:
 
+### December 2021
+
+#### Docs
+
+- Updated [DIY instructions](https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/README-AzureChina.md) for deploying Enterprise-Scale in Azure China with:
+  - Additional details of some deployment steps
+  - Microsoft Defender for Cloud configuration policy set definition and policy assignment specific to Azure China
+  - Differentiate between Az Vm Backup policy assignment for identity management group, and landing zone management group in the DIY guidance
+
+### Policy
+
+- The following policy definitions for Microsoft Defender for Cloud configurations are not available as built-in in Azure China. The policy set definition will be updated as when these policy definitions are available:
+  - defenderForOssDb, defenderForSqlServerVirtualMachines, defenderForAppServices, defenderForAppServices, defenderForStorageAccounts, defenderForKubernetesService, defenderForKeyVaults, defenderForDns, defenderForArm
+  - defenderForContainerRegistry - this built-in policy has been deprecated
+  
 ### November 2021
 
 #### Docs

--- a/eslzArm/README-AzureChina.md
+++ b/eslzArm/README-AzureChina.md
@@ -136,25 +136,16 @@ New-AzManagementGroupDeployment -Name "$($DeploymentName)-resource-diag" `
                                 -ManagementGroupId $ESLZPrefix `
                                 -Verbose
 
-# Assign Azure Policy to enforce Azure Security Center configuration enabled on all subscriptions, deployed to top level management group
+# Assign Azure Policy to enforce Microsoft Defender for Cloud configuration enabled on all subscriptions, deployed to top level management group
 
 New-AzManagementGroupDeployment -Name "$($DeploymentName)-asc-config" `
                                 -Location $Location `
-                                -TemplateFile .\eslzArm\managementGroupTemplates\policyAssignments\DINE-ASCConfigPolicyAssignment.json `
+                                -TemplateFile .\eslzArm\managementGroupTemplates\policyAssignments\china\mcDINE-ASCConfigPolicyAssignment.json `
                                 -ManagementGroupId $eslzPrefix `
                                 -topLevelManagementGroupPrefix $ESLZPrefix `
                                 -logAnalyticsResourceId "/subscriptions/$($ManagementSubscriptionId)/resourceGroups/$($eslzPrefix)-mgmt/providers/Microsoft.OperationalInsights/workspaces/$($eslzPrefix)-law" `
                                 -enableAscForServers "DeployIfNotExists" `
                                 -enableAscForSql "DeployIfNotExists" `
-                                -enableAscForAppServices "DeployIfNotExists" `
-                                -enableAscForStorage "DeployIfNotExists" `
-                                -enableAscForRegistries "DeployIfNotExists" `
-                                -enableAscForKeyVault "DeployIfNotExists" `
-                                -enableAscForSqlOnVm "DeployIfNotExists" `
-                                -enableAscForKubernetes "DeployIfNotExists" `
-                                -enableAscForArm "DeployIfNotExists" `
-                                -enableAscForDns "DeployIfNotExists" `
-                                -enableAscForOssDb "DeployIfNotExists" `
                                 -emailContactAsc $SecurityContactEmailAddress `
                                 -Verbose
 
@@ -215,7 +206,7 @@ New-AzManagementGroupDeployment -Name "$($DeploymentName)-public-ip" `
 # Assign Azure Policy to enforce VM Backup on VMs in the identity subscription
 
 New-AzManagementGroupDeployment -Name "$($DeploymentName)-vm-backup" `
-                                -Location $Location `
+                                -Location $Location `pwd
                                 -ManagementGroupId "$($ESLZPrefix)-identity" `
                                 -TemplateFile .\eslzArm\managementGroupTemplates\policyAssignments\DINE-VMBackupPolicyAssignment.json `
                                 -topLevelManagementGroupPrefix $eslzPrefix `

--- a/eslzArm/README-AzureChina.md
+++ b/eslzArm/README-AzureChina.md
@@ -28,7 +28,7 @@ New-AzManagementGroupDeployment -Name $DeploymentName `
                                 -Verbose
 
 # Deploy core policy definitions to ESLZ intermediate root management group
-# Note: If your ProvisioningState is "Failed", please go to your top level management group prefix under Management Groups in the Azure Portal, under Governance click "Deployments", click on the deployment with the post-fix "-policy1". If the Operation Details show that the policy set definition request is invalid because some policy definition could not be found, this is often due to a race condition which happens during which ARM is deploying both the policy set definitions and the policy definitions at the same time. Please wait for awhile and re-run the Azure Powershell command to deploy the mcPolicies.json template and this would result in a "Succeeded" ProvisioningState.
+# Note: If your ProvisioningState is "Failed", please go to your top level management group prefix under Management Groups in the Azure Portal, under Governance click "Deployments", click on the deployment with the post-fix "-policy1". If the Operation Details show that the policy set definition request is invalid because some policy definition could not be found, this is often due to a known replication delay. Please re-run the deployment step below, and the deployment should succeed.
 
 New-AzManagementGroupDeployment -Name "$($DeploymentName)-policy1" `
                                 -ManagementGroupId $ESLZPrefix `

--- a/eslzArm/managementGroupTemplates/policyAssignments/china/mcDINE-ASCConfigPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/china/mcDINE-ASCConfigPolicyAssignment.json
@@ -25,7 +25,7 @@
         "emailContactAsc": {
             "type": "string",
             "metadata": {
-                "description": "Provide the email address to the ASC security contact."
+                "description": "Provide the email address to the Microsoft Defender for Cloud security contact."
             }
         },
         "enableAscForServers": {

--- a/eslzArm/managementGroupTemplates/policyAssignments/china/mcDINE-ASCConfigPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/china/mcDINE-ASCConfigPolicyAssignment.json
@@ -1,0 +1,113 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "topLevelManagementGroupPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide the ESLZ company prefix to the intermediate root management group containing the policy definitions."
+            }
+        },
+        "enforcementMode": {
+            "type": "string",
+            "allowedValues": [
+                "Default",
+                "DoNotEnforce"
+            ],
+            "defaultValue": "Default"
+        },
+        "logAnalyticsResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide the resourceId to the central Log Analytics workspace."
+            }
+        },
+        "emailContactAsc": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide the email address to the ASC security contact."
+            }
+        },
+        "enableAscForServers": {
+            "type": "string",
+            "allowedValues": [
+                "Disabled",
+                "DeployIfNotExists"
+            ],
+            "defaultValue": "Disabled"            
+        },
+        "enableAscForSql": {
+            "type": "string",
+            "allowedValues": [
+                "Disabled",
+                "DeployIfNotExists"
+            ],
+            "defaultValue": "Disabled"            
+        }
+    },
+    "variables": {
+        "policyDefinitions": {
+            "deployAzureSecurity": "[concat('/providers/Microsoft.Management/managementGroups/', parameters('topLevelManagementGroupPrefix'), '/providers/Microsoft.Authorization/policySetDefinitions/Deploy-ASCDF-Config')]"
+        },
+        "policyAssignmentNames": {
+            "azureSecurity": "Deploy-ASCDF-Config",
+            "description": "Deploy Microsoft Defender for Cloud and Security Contacts",
+            "displayName": "Deploy Microsoft Defender for Cloud configuration"
+        },
+        "rbacOwner": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+        "roleAssignmentNames": {
+            "deployAzureSecurity": "[guid(concat(parameters('toplevelManagementGroupPrefix'),variables('policyAssignmentNames').azureSecurity))]"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Authorization/policyAssignments",
+            "apiVersion": "2019-09-01",
+            "name": "[variables('policyAssignmentNames').azureSecurity]",
+            "location": "[deployment().location]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "description": "[variables('policyAssignmentNames').description]",
+                "displayName": "[variables('policyAssignmentNames').displayName]",
+                "policyDefinitionId": "[variables('policyDefinitions').deployAzureSecurity]",
+                "enforcementMode": "[parameters('enforcementMode')]",
+                "parameters": {
+                    "emailSecurityContact": {
+                        "value": "[parameters('emailContactAsc')]"
+                    },
+                    "logAnalytics": {
+                        "value": "[parameters('logAnalyticsResourceId')]"
+                    },
+                    "ascExportResourceGroupName": {
+                        "value": "[concat(parameters('topLevelManagementGroupPrefix'), '-asc-export')]"
+                    },
+                    "ascExportResourceGroupLocation": {
+                        "value": "[deployment().location]"
+                    },
+                    "enableAscForServers": {
+                        "value": "[parameters('enableAscForServers')]"
+                    },
+                    "enableAscForSql": {
+                        "value": "[parameters('enableAscForSql')]"
+                    }
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2019-04-01-preview",
+            "name": "[variables('roleAssignmentNames').deployAzureSecurity]",
+            "dependsOn": [
+                "[variables('policyAssignmentNames').azureSecurity]"
+            ],
+            "properties": {
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[concat('/providers/Microsoft.Authorization/roleDefinitions/', variables('rbacOwner'))]",
+                "principalId": "[toLower(reference(concat('/providers/Microsoft.Authorization/policyAssignments/', variables('policyAssignmentNames').azureSecurity), '2019-09-01', 'Full' ).identity.principalId)]"
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/eslzArm/managementGroupTemplates/policyDefinitions/china/mcPolicies.json
+++ b/eslzArm/managementGroupTemplates/policyDefinitions/china/mcPolicies.json
@@ -16229,7 +16229,7 @@
                 "type": "string",
                 "metadata": {
                   "displayName": "Security contacts email address",
-                  "description": "Provide email address for Azure Security Center contact details"
+                  "description": "Provide email address for Microsoft Defender for Cloud contact details"
                 }
               },
               "logAnalytics": {
@@ -16254,70 +16254,7 @@
                   "description": "The location where the resource group and the export to Log Analytics workspace configuration are created."
                 }
               },
-              "enableAscForKubernetes": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
               "enableAscForSql": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForSqlOnVm": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForDns": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForArm": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForOssDb": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForAppServices": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForRegistries": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForKeyVault": {
-                "type": "String",
-                "metadata": {
-                  "displayName": "Effect",
-                  "description": "Enable or disable the execution of the policy"
-                }
-              },
-              "enableAscForStorage": {
                 "type": "String",
                 "metadata": {
                   "displayName": "Effect",
@@ -16338,92 +16275,11 @@
             },
             "PolicyDefinitions": [
               {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/44433aa3-7ec2-4002-93ea-65c65ff0310a",
-                "policyDefinitionReferenceId": "defenderForOssDb",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForOssDb')]"
-                  }
-                }
-              },
-              {
                 "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/8e86a5b6-b9bd-49d1-8e21-4bb8a0862222",
                 "policyDefinitionReferenceId": "defenderForVM",
                 "parameters": {
                   "effect": {
                     "value": "[[parameters('enableAscForServers')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/50ea7265-7d8c-429e-9a7d-ca1f410191c3",
-                "policyDefinitionReferenceId": "defenderForSqlServerVirtualMachines",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForSqlOnVm')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b40e7bcd-a1e5-47fe-b9cf-2f534d0bfb7d",
-                "policyDefinitionReferenceId": "defenderForAppServices",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForAppServices')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/74c30959-af11-47b3-9ed2-a26e03f427a3",
-                "policyDefinitionReferenceId": "defenderForStorageAccounts",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForStorage')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/64def556-fbad-4622-930e-72d1d5589bf5",
-                "policyDefinitionReferenceId": "defenderForKubernetesService",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForKubernetes')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d3d1e68e-49d4-4b56-acff-93cef644b432",
-                "policyDefinitionReferenceId": "defenderForContainerRegistry",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForRegistries')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1f725891-01c0-420a-9059-4fa46cb770b7",
-                "policyDefinitionReferenceId": "defenderForKeyVaults",
-                "parameters": {
-                  "Effect": {
-                    "value": "[[parameters('enableAscForKeyVault')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/2370a3c1-4a25-4283-a91a-c9c1a145fb2f",
-                "policyDefinitionReferenceId": "defenderForDns",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForDns')]"
-                  }
-                }
-              },
-              {
-                "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b7021b2b-08fd-4dc0-9de7-3c6ece09faf9",
-                "policyDefinitionReferenceId": "defenderForArm",
-                "parameters": {
-                  "effect": {
-                    "value": "[[parameters('enableAscForArm')]"
                   }
                 }
               },


### PR DESCRIPTION
## Mooncake updates

1. Tracked in issue #867  

## This PR fixes/adds/changes/removes

1. Updated [DIY instructions](https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/README-AzureChina.md) for deploying Enterprise-Scale in Azure China with:
- Additional details of some deployment steps
- Microsoft Defender for Cloud configuration policy set definition and policy assignment specific to Azure China
- Differentiate between Az Vm Backup policy assignment for identity management group, and landing zone management group in the DIY guidance
2. The following policy definitions for Microsoft Defender for Cloud configurations are not available as built-in in Azure China. The policy set definition will be updated as when these policy definitions are available:
- defenderForOssDb, defenderForSqlServerVirtualMachines, defenderForAppServices, defenderForAppServices, defenderForStorageAccounts, defenderForKubernetesService, defenderForKeyVaults, defenderForDns, defenderForArm
- defenderForContainerRegistry - this built-in policy has been deprecated (see below, I saw this is also the case for Azure global regions)
- 
![image](https://user-images.githubusercontent.com/8053228/145003951-c18e1df6-d41d-4117-8391-745135b1a417.png)

### Breaking Changes

None.

## Testing Evidence
![image](https://user-images.githubusercontent.com/8053228/145004107-09b1c26d-44f1-442e-9b79-60fe5e5ddfbb.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
