### PR TITLE
Change wording and link

### DIFF
--- a/docs/Deploy/deploy-lz-vnet.md
+++ b/docs/Deploy/deploy-lz-vnet.md
@@ -52,8 +52,7 @@ which will give you a "one-click" end-to-end deployment experience.
 
 ## Azure Policy - Landing Zone VNet Deployment
 
-We currently provide two policies to deploy VNets in landing zone and
-peer them to either traditional VNet hubs or Azure Virtual Wan Hubs. The policy definition can be found [here](https://github.com/Azure/Enterprise-Scale/blob/main/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560%20(3fc1081d-6105-4e19-b60c-1ec1252cf560)/ESLZ%20(ESLZ)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-VNET-HubSpoke.parameters.json).
+We currently provide a policy to deploy VNets in landing zones and peer them to a traditional VNet hub. This policy definition (Deploy-VNET-HubSpoke) is part of the greater set of policies provided as standard in the template found [here](https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/managementGroupTemplates/policyDefinitions/policies.json).
 
 ### Deploy-VNet-HubSpoke - Assignment at subscription
 

--- a/docs/Deploy/deploy-lz-vnet.md
+++ b/docs/Deploy/deploy-lz-vnet.md
@@ -52,7 +52,7 @@ which will give you a "one-click" end-to-end deployment experience.
 
 ## Azure Policy - Landing Zone VNet Deployment
 
-We currently provide a policy to deploy VNets in landing zones and peer them to a traditional VNet hub. This policy definition (Deploy-VNET-HubSpoke) is part of the greater set of policies provided as standard in the template found [here](https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/managementGroupTemplates/policyDefinitions/policies.json).
+We currently provide a policy to deploy VNets in landing zones and peer them to a traditional VNet hub. This policy definition (Deploy-VNET-HubSpoke) is part of the greater set of policies provided as standard in the template found [here](https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/managementGroupTemplates/policyDefinitions/policies.json#L878).
 
 ### Deploy-VNet-HubSpoke - Assignment at subscription
 


### PR DESCRIPTION
**Overview/Summary**
This pull request addresses the issue described in #856

This PR fixes/adds/changes/removes
- Change path to template containing Deploy-VNET-HubSpoke policy from https://github.com/Azure/Enterprise-Scale/blob/main/azopsreference/3fc1081d-6105-4e19-b60c-1ec1252cf560%20(3fc1081d-6105-4e19-b60c-1ec1252cf560)/ESLZ%20(ESLZ)/.AzState/Microsoft.Authorization_policyDefinitions-Deploy-VNET-HubSpoke.parameters.json to https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/managementGroupTemplates/policyDefinitions/policies.json
- Change wording to specify that there is only one policy and it only deploys  a vnet and peering in a hub/spoke scenario. No support for Virtual WAN virtual network connections is provided. 

### Breaking Changes

N/A

## Testing Evidence

Not required since this is all documentation.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`) **_Not required since this is a very minor documentation change._**
