### PR TITLE
Policy: Deploy-Diagnostics-MlWorkspace fix

### DIFF
--- a/eslzArm/managementGroupTemplates/policyDefinitions/china/mcPolicies.json
+++ b/eslzArm/managementGroupTemplates/policyDefinitions/china/mcPolicies.json
@@ -6023,39 +6023,12 @@
                               "workspaceId": "[[parameters('logAnalytics')]",
                               "metrics": [
                                 {
-                                  "category": "Run",
+                                  "category": "AllMetrics",
                                   "enabled": "[[parameters('metricsEnabled')]",
                                   "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": false
-                                  },
-                                  "timeGrain": null
-                                },
-                                {
-                                  "category": "Model",
-                                  "enabled": "[[parameters('metricsEnabled')]",
-                                  "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": true
+                                    "enabled": false,
+                                    "days": 0
                                   }
-                                },
-                                {
-                                  "category": "Quota",
-                                  "enabled": "[[parameters('metricsEnabled')]",
-                                  "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": false
-                                  },
-                                  "timeGrain": null
-                                },
-                                {
-                                  "category": "Resource",
-                                  "enabled": "[[parameters('metricsEnabled')]",
-                                  "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": false
-                                  },
-                                  "timeGrain": null
                                 }
                               ],
                               "logs": [
@@ -6077,6 +6050,90 @@
                                 },
                                 {
                                   "category": "AmlRunStatusChangedEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ModelsChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ModelsReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ModelsActionEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DeploymentReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DeploymentEventACI",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DeploymentEventAKS",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "InferencingOperationAKS",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "InferencingOperationACI",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataLabelChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataLabelReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ComputeInstanceEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataStoreChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataStoreReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataSetChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataSetReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "PipelineChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "PipelineReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "RunEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "RunReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "EnvironmentChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "EnvironmentReadEvent",
                                   "enabled": "[[parameters('logsEnabled')]"
                                 }
                               ]

--- a/eslzArm/managementGroupTemplates/policyDefinitions/gov/fairfaxPolicies.json
+++ b/eslzArm/managementGroupTemplates/policyDefinitions/gov/fairfaxPolicies.json
@@ -6069,39 +6069,12 @@
                               "workspaceId": "[[parameters('logAnalytics')]",
                               "metrics": [
                                 {
-                                  "category": "Run",
+                                  "category": "AllMetrics",
                                   "enabled": "[[parameters('metricsEnabled')]",
                                   "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": false
-                                  },
-                                  "timeGrain": null
-                                },
-                                {
-                                  "category": "Model",
-                                  "enabled": "[[parameters('metricsEnabled')]",
-                                  "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": true
+                                    "enabled": false,
+                                    "days": 0
                                   }
-                                },
-                                {
-                                  "category": "Quota",
-                                  "enabled": "[[parameters('metricsEnabled')]",
-                                  "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": false
-                                  },
-                                  "timeGrain": null
-                                },
-                                {
-                                  "category": "Resource",
-                                  "enabled": "[[parameters('metricsEnabled')]",
-                                  "retentionPolicy": {
-                                    "days": 0,
-                                    "enabled": false
-                                  },
-                                  "timeGrain": null
                                 }
                               ],
                               "logs": [
@@ -6123,6 +6096,90 @@
                                 },
                                 {
                                   "category": "AmlRunStatusChangedEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ModelsChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ModelsReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ModelsActionEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DeploymentReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DeploymentEventACI",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DeploymentEventAKS",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "InferencingOperationAKS",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "InferencingOperationACI",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataLabelChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataLabelReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "ComputeInstanceEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataStoreChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataStoreReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataSetChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "DataSetReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "PipelineChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "PipelineReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "RunEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "RunReadEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "EnvironmentChangeEvent",
+                                  "enabled": "[[parameters('logsEnabled')]"
+                                },
+                                {
+                                  "category": "EnvironmentReadEvent",
                                   "enabled": "[[parameters('logsEnabled')]"
                                 }
                               ]

--- a/eslzArm/managementGroupTemplates/policyDefinitions/policies.json
+++ b/eslzArm/managementGroupTemplates/policyDefinitions/policies.json
@@ -991,8 +991,8 @@
                                                 "variables": {
                                                     "copyLoop": [
                                                         {
-                                                        "name": "routes",
-                                                        "count": "[[[length(parameters('requiredRoutes'))]",
+                                                            "name": "routes",
+                                                            "count": "[[[length(parameters('requiredRoutes'))]",
                                                             "input": {
                                                                 "name": "[[[concat('route-',copyIndex('routes'))]",
                                                                 "properties": {
@@ -1056,21 +1056,21 @@
                                                                 }
                                                             }
                                                         }
-                                                    }   
+                                                    }
                                                 ]
                                             },
                                             "parameters": {
                                                 "routeTableName": {
-                                                "value": "[[parameters('routeTableName')]"
+                                                    "value": "[[parameters('routeTableName')]"
                                                 },
                                                 "vnetRegion": {
-                                                "value": "[[parameters('vnetRegion')]"
+                                                    "value": "[[parameters('vnetRegion')]"
                                                 },
                                                 "requiredRoutes": {
-                                                "value": "[[parameters('requiredRoutes')]"
+                                                    "value": "[[parameters('requiredRoutes')]"
                                                 },
                                                 "disableBgpPropagation": {
-                                                "value": "[[parameters('disableBgpPropagation')]"
+                                                    "value": "[[parameters('disableBgpPropagation')]"
                                                 }
                                             }
                                         }
@@ -6151,39 +6151,12 @@
                                                             "workspaceId": "[[parameters('logAnalytics')]",
                                                             "metrics": [
                                                                 {
-                                                                    "category": "Run",
+                                                                    "category": "AllMetrics",
                                                                     "enabled": "[[parameters('metricsEnabled')]",
                                                                     "retentionPolicy": {
-                                                                        "days": 0,
-                                                                        "enabled": false
-                                                                    },
-                                                                    "timeGrain": null
-                                                                },
-                                                                {
-                                                                    "category": "Model",
-                                                                    "enabled": "[[parameters('metricsEnabled')]",
-                                                                    "retentionPolicy": {
-                                                                        "days": 0,
-                                                                        "enabled": true
+                                                                        "enabled": false,
+                                                                        "days": 0
                                                                     }
-                                                                },
-                                                                {
-                                                                    "category": "Quota",
-                                                                    "enabled": "[[parameters('metricsEnabled')]",
-                                                                    "retentionPolicy": {
-                                                                        "days": 0,
-                                                                        "enabled": false
-                                                                    },
-                                                                    "timeGrain": null
-                                                                },
-                                                                {
-                                                                    "category": "Resource",
-                                                                    "enabled": "[[parameters('metricsEnabled')]",
-                                                                    "retentionPolicy": {
-                                                                        "days": 0,
-                                                                        "enabled": false
-                                                                    },
-                                                                    "timeGrain": null
                                                                 }
                                                             ],
                                                             "logs": [
@@ -6205,6 +6178,90 @@
                                                                 },
                                                                 {
                                                                     "category": "AmlRunStatusChangedEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "ModelsChangeEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "ModelsReadEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "ModelsActionEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DeploymentReadEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DeploymentEventACI",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DeploymentEventAKS",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "InferencingOperationAKS",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "InferencingOperationACI",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DataLabelChangeEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DataLabelReadEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "ComputeInstanceEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DataStoreChangeEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DataStoreReadEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DataSetChangeEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "DataSetReadEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "PipelineChangeEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "PipelineReadEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "RunEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "RunReadEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "EnvironmentChangeEvent",
+                                                                    "enabled": "[[parameters('logsEnabled')]"
+                                                                },
+                                                                {
+                                                                    "category": "EnvironmentReadEvent",
                                                                     "enabled": "[[parameters('logsEnabled')]"
                                                                 }
                                                             ]


### PR DESCRIPTION
## Overview/Summary

This PR fixes the issue that is described here: #893 

Original policy contains metrics which doesn't exists, operation message:
Metric category 'Run' is not supported, supported categories are: 'AllMetrics'.

All logs are enabled in this PR.

## This PR fixes/adds/changes/removes

1. #893 

### Breaking Changes

## Testing Evidence

Activity Log:
![Deploy-Diagnostics-MlWorkspace-after-PR-activitylog](https://user-images.githubusercontent.com/2323352/149982870-e639b3d1-4530-4547-b09c-b0bee9ab7678.jpg)

Diagnostics settings result Machine Learning workspace:
![Deploy-Diagnostics-MlWorkspace-after-PR-result](https://user-images.githubusercontent.com/2323352/149982867-224cec16-479e-430b-92ba-c251296b7be6.jpg)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
