### PR TITLE
Fix casing on CODEOWNERS teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-.github/CODEOWNERS @Azure/ESLZ-CodeOwnersAdmins
-.github/** @Azure/ESLZ-Admins
-eslzArm/** @Azure/ESLZ-ArmTeam
+.github/CODEOWNERS @Azure/eslz-codeownersadmins
+.github/** @Azure/eslz-admins
+eslzArm/** @Azure/eslz-armteam


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The current CODEOWNERS has not been working as expected.

Fixing casing on CODEOWNERS file for same teams as already defined to match their representation in GitHub Teams. As per docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

![image](https://user-images.githubusercontent.com/12268562/154293056-9886057b-bc1b-4822-9542-656d4c6fac79.png)

Group names shown below in lowercase:

![image](https://user-images.githubusercontent.com/41163455/154292509-635c12f4-de2f-4336-8bbd-1944adf7ccb5.png)


## This PR fixes/adds/changes/removes

1. Fixing casing on CODEOWNERS file for same teams as already defined to match their representation in GitHub Teams

### Breaking Changes

None

## Testing Evidence

Not possible

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
