### PR TITLE
Add Firewall Policy resource for VWAN implementation

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -47,8 +47,9 @@ Here's what's changed in Enterprise Scale:
 
 - The Bicep version of Azure Landing Zone (formerly Enterprise-scale) is here! 🥳
   - Check out the [ALZ-Bicep repo](https://github.com/Azure/ALZ-Bicep) to get started!
-- Updated accelerator (portal) experience to deploy a Azure Firewall Policy `Premium` SKU instead of `Standard` when `Premium` is selected for the Azure Firewall in a Hub & Spoke VNet Connectivity model. 
-  - [PR 890](https://github.com/Azure/Enterprise-Scale/pull/890) fixing [issue 889](https://github.com/Azure/Enterprise-Scale/issues/889) 
+- Updated accelerator (portal) experience to deploy an Azure Firewall Policy `Premium` SKU instead of `Standard` when `Premium` is selected for the Azure Firewall in a Hub & Spoke VNet Connectivity model.
+  - [PR 890](https://github.com/Azure/Enterprise-Scale/pull/890) fixing [issue 889](https://github.com/Azure/Enterprise-Scale/issues/889)
+- Updated accelerator (portal) experience to deploy an Azure Firewall Policy for customers using the Virtual WAN connectivity model.
 
 ### Policy
 

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1745,6 +1745,9 @@
                     "firewallSku": {
                         "value": "[parameters('firewallSku')]"
                     },
+                    "enableAzFwDnsProxy": {
+                        "value": "[parameters('enableAzFwDnsProxy')]"
+                    },
                     "addressPrefix": {
                         "value": "[parameters('addressPrefix')]"
                     },

--- a/eslzArm/subscriptionTemplates/vwan-connectivity.json
+++ b/eslzArm/subscriptionTemplates/vwan-connectivity.json
@@ -49,6 +49,17 @@
             ],
             "defaultValue": "Standard"
         },
+        "enableAzFwDnsProxy": {
+            "type": "string",
+            "allowedValues": [
+                "Yes",
+                "No"
+            ],
+            "defaultValue": "No",
+            "metadata": {
+                "description": "Select whether the Azure Firewall should be used as DNS Proxy or not."
+            }
+        },
         "enableVpnGw": {
             "type": "string",
             "allowedValues": [
@@ -93,6 +104,9 @@
         "resourceDeploymentName": "[take(concat(deployment().name, '-vwan'), 64)]",
         "azFirewallPolicyId": {
             "id": "[concat('/subscriptions/', parameters('connectivitySubscriptionId'), '/resourceGroups/', variables('rgName'), '/providers/Microsoft.Network/firewallPolicies/', variables('azFwPolicyName'))]"
+        },
+        "azFirewallDnsSettings": {
+            "enableProxy": true
         }
     },
     "resources": [
@@ -205,7 +219,7 @@
                                             "name": "[variables('azFwPolicyName')]",
                                             "location": "[parameters('location')]",
                                             "properties": {
-                                                "dnsSettings": "[json('null')]",
+                                                "dnsSettings": "[if(equals(parameters('enableAzFwDnsProxy'), 'Yes'), variables('azFirewallDnsSettings'), json('null'))]",
                                                 "sku": {
                                                     "tier": "[parameters('firewallSku')]"
                                                 }

--- a/eslzArm/subscriptionTemplates/vwan-connectivity.json
+++ b/eslzArm/subscriptionTemplates/vwan-connectivity.json
@@ -84,12 +84,16 @@
         "rgName": "[concat(parameters('topLevelManagementGroupPrefix'), '-vnethub-', parameters('location'))]",
         "vHubName": "[concat(parameters('topLevelManagementGroupPrefix'), '-hub-', parameters('location'))]",
         "azFwName": "[concat(parameters('topLevelManagementGroupPrefix'), '-fw-', parameters('location'))]",
+        "azFwPolicyName": "[concat(parameters('topLevelManagementGroupPrefix'), '-azfwpolicy-', parameters('location'))]",
         "vWanSku": "Standard",
         "vwanresourceid": "[concat('/subscriptions/', parameters('connectivitySubscriptionId'), '/resourceGroups/' ,variables('rgName'),'/providers/Microsoft.Network/virtualWans/', variables('vwanname'))]",
         "vwanhub": "[concat('/subscriptions/', parameters('connectivitySubscriptionId'), '/resourceGroups/', variables('rgName'),'/providers/Microsoft.Network/virtualHubs/', variables('vhubname'))]",
         "vhubsku": "Standard",
         "vpnbgpasn": 65515,
-        "resourceDeploymentName": "[take(concat(deployment().name, '-vwan'), 64)]"
+        "resourceDeploymentName": "[take(concat(deployment().name, '-vwan'), 64)]",
+        "azFirewallPolicyId": {
+            "id": "[concat('/subscriptions/', parameters('connectivitySubscriptionId'), '/resourceGroups/', variables('rgName'), '/providers/Microsoft.Network/firewallPolicies/', variables('azFwPolicyName'))]"
+        }
     },
     "resources": [
         {
@@ -196,11 +200,25 @@
                                         },
                                         {
                                             "condition": "[equals(parameters('enableAzFw'), 'Yes')]",
+                                            "type": "Microsoft.Network/firewallPolicies",
+                                            "apiVersion": "2020-11-01",
+                                            "name": "[variables('azFwPolicyName')]",
+                                            "location": "[parameters('location')]",
+                                            "properties": {
+                                                "dnsSettings": "[json('null')]",
+                                                "sku": {
+                                                    "tier": "[parameters('firewallSku')]"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "condition": "[equals(parameters('enableAzFw'), 'Yes')]",
                                             "apiVersion": "2020-05-01",
                                             "type": "Microsoft.Network/azureFirewalls",
                                             "name": "[variables('azfwname')]",
                                             "location": "[parameters('location')]",
                                             "dependsOn": [
+                                                "[concat('Microsoft.Network/firewallPolicies/', variables('azFwPolicyName'))]",
                                                 "[concat('Microsoft.Network/virtualHubs/',variables('vhubname'))]"
                                             ],
                                             "properties": {
@@ -218,7 +236,7 @@
                                                     "id": "[variables('vwanhub')]"
                                                 },
                                                 "firewallPolicy": {
-                                                    "id": "[json('null')]"
+                                                    "id": "[variables('azFirewallPolicyId').id]"
                                                 }
                                             }
                                         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Currently, only the Hub & Spoke implementation includes a Firewall Policy for the Azure Firewall deployment.

This PR adds creation of a Firewall Policy and associates it with the Azure Firewall deployed to a Virtual Hub.

I have used all existing input parameters, so no changes should be needed in the Portal experience.

## This PR fixes/adds/changes/removes

1. Add a `Microsoft.Network/firewallPolicies` resource and link it to the `Microsoft.Network/azureFirewalls` resource in the `eslzArm/subscriptionTemplates/vwan-connectivity.json` deployment template.
2. Add this update to the `docs/wiki/Whats-new.md` page.

### Breaking Changes

none

## Testing Evidence

![image](https://user-images.githubusercontent.com/12268562/154447182-ac226381-479b-4225-89db-dc058d72c7d3.png)

![image](https://user-images.githubusercontent.com/12268562/154447318-65cbe80f-7a96-457b-a099-136235f8e3ce.png)

![image](https://user-images.githubusercontent.com/12268562/154447417-6b8749c1-f73b-489f-a996-3fd54c849c84.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)

> **NOTE**: I do not believe there are any Wiki docs which need updating with this change (other than the What's new page) but please let me know if this would be useful to add somewhere.