### PR TITLE
Add FabricBot Config-as-Code

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,1599 @@
+[
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "noActivitySince",
+                "parameters": {
+                  "days": 7
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "none"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+      "actions": [
+        {
+          "name": "reopenIssue",
+          "parameters": {}
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Needs: Attention :wave:"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "none"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 7
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hello, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isClosed",
+          "parameters": {}
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 30
+          }
+        },
+        {
+          "name": "isUnlocked",
+          "parameters": {}
+        },
+        {
+          "name": "isIssue",
+          "parameters": {}
+        }
+      ],
+      "taskName": "Lock issues closed without activity for over 30 days",
+      "actions": [
+        {
+          "name": "lockIssue",
+          "parameters": {
+            "reason": "resolved"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Add needs triage label to new issues",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isPartOfProject",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAssignedToSomeone",
+                "parameters": {}
+              }
+            ]
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Needs: Triage :mag:"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Replace needs author feedback label with needs attention label when the author comments on an issue",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Needs: Attention :wave:"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label from issues",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label when an issue is commented on",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Close stale issues",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 3
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    },
+    "disabled": true
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Add no recent activity label to issues",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 5
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "long term"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **5 days**."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Close duplicate issues",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "duplicate"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 1
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes."
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "InPrLabel",
+    "subCapability": "InPrLabel",
+    "version": "1.0",
+    "config": {
+      "taskName": "Add 'In-PR' label on issue when an open pull request is targeting it",
+      "inPrLabelText": "Status: In PR",
+      "fixedLabelText": "Status: Fixed",
+      "fixedLabelEnabled": true
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Add needs author feedback label to pull requests when changes are requested",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "submitted"
+            }
+          },
+          {
+            "name": "isReviewState",
+            "parameters": {
+              "state": "changes_requested"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove needs author feedback label when the author responds to a pull request",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove needs author feedback label when the author comments on a pull request",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove needs author feedback label when the author responds to a pull request review comment",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label from pull requests",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label when a pull request is commented on",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label when a pull request is reviewed",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Close stale pull requests",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 7
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    },
+    "disabled": true
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Add no recent activity label to pull requests",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            0,
+            3,
+            6,
+            9,
+            12,
+            15,
+            18,
+            21
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 7
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "EmailCleanser",
+    "subCapability": "EmailCleanser",
+    "version": "1.0",
+    "config": {
+      "taskName": "Clean those e-mail replies"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "AutoMerge",
+    "subCapability": "AutoMerge",
+    "version": "1.0",
+    "config": {
+      "allowAutoMergeInstructionsWithoutLabel": true,
+      "mergeType": "squash",
+      "deleteBranches": true,
+      "enforceDMPAsStatus": true,
+      "removeLabelOnPush": true,
+      "label": "auto merge :heavy_check_mark:",
+      "taskName": "Auto-merge PRs",
+      "requireAllStatuses": false,
+      "requireSpecificCheckRuns": false,
+      "usePrDescriptionAsCommitMessage": false,
+      "minMinutesOpen": "480"
+    },
+    "disabled": true
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isPartOfProject",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAssignedToSomeone",
+                "parameters": {}
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add needs triage label to new PRs",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Needs: Triage :mag:"
+          }
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Adds the `fabricbot.json` config file from the FabricBot config portal to the correct location of `.github/`

## This PR fixes/adds/changes/removes

1. Fixes #933 

### Breaking Changes

**None**

## Testing Evidence

This has been done in the ALZ-Bicep repo successfully. https://github.com/Azure/ALZ-Bicep/blob/main/.github/fabricbot.json

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
