### PR TITLE
Update EnterpriseScale-Setup-azure.md

### DIFF
--- a/docs/EnterpriseScale-Setup-azure.md
+++ b/docs/EnterpriseScale-Setup-azure.md
@@ -50,11 +50,8 @@ PowerShell
 #sign in to Azure from Powershell, this will redirect you to a webbrowser for authentication, if required
 Connect-AzAccount
 
-#get object Id of the current user (that is used above)
-$user = Get-AzADUser -UserPrincipalName (Get-AzContext).Account
-
 #assign Owner role at Tenant root scope ("/") as a User Access Administrator to current user
-New-AzRoleAssignment -Scope '/' -RoleDefinitionName 'Owner' -ObjectId $user.Id
+New-AzRoleAssignment -Scope '/' -RoleDefinitionName 'Owner' -ObjectId (Get-AzADUser -SignedIn).Id
 
 #(optional) assign Owner role at Tenant root scope ("/") as a User Access Administrator to service principal (set $spndisplayname to your service principal displayname)
 $spndisplayname = "<ServicePrincipal DisplayName>"


### PR DESCRIPTION
changing powershell cmdlet

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

(Get-AzContext).Account now returns User object, not the UPN so changed it with different cmdlet 

## This PR fixes/adds/changes/removes

1. removed $user defining area
2. change argument of ObjectId from $user.Id to (Get-AzAdUser -SignedIn).Id

## Testing Evidence

![image](https://user-images.githubusercontent.com/3829473/160049809-9a4ea2d7-3836-483c-ab90-91344134c1fc.png)
