### PR TITLE
Update EnterpriseScale-Setup-azure.md

### DIFF
--- a/docs/EnterpriseScale-Setup-azure.md
+++ b/docs/EnterpriseScale-Setup-azure.md
@@ -37,7 +37,7 @@ az login
 read -sp "Azure password: " AZ_PASS && echo && az login -u <username> -p $AZ_PASS
 
 #assign Owner role at Tenant root scope ("/") as a User Access Administrator to current user (gets object Id of the current user (az login))
-az role assignment create --scope '/' --role 'Owner' --assignee-object-id $(az ad signed-in-user show --query objectId --output tsv) --assignee-principal-type User
+az role assignment create --scope '/' --role 'Owner' --assignee-object-id $(az ad signed-in-user show --query id --output tsv) --assignee-principal-type User
 
 #(optional) assign Owner role at Tenant root scope ("/") as a User Access Administrator to service principal (set spn_displayname to your service principal displayname)
 spn_displayname='<ServicePrincipal DisplayName>'

--- a/docs/wiki/Deploying-Enterprise-Scale-Pre-requisites.md
+++ b/docs/wiki/Deploying-Enterprise-Scale-Pre-requisites.md
@@ -37,7 +37,7 @@ Bash:
 az login
 
 #assign Owner role to Tenant root scope  ("/") as a Owner (gets object Id of the current user (az login))
-az role assignment create --scope '/'  --role 'Owner' --assignee-object-id $(az ad signed-in-user show --query "objectId" --output tsv)
+az role assignment create --scope '/'  --role 'Owner' --assignee-object-id $(az ad signed-in-user show --query id --output tsv)
 ```
 
 Powershell:

--- a/docs/wiki/Deploying-Enterprise-Scale.md
+++ b/docs/wiki/Deploying-Enterprise-Scale.md
@@ -50,7 +50,7 @@ Bash:
 az login
 
 #assign Owner role to Tenant root scope  ("/") as a Owner (gets object Id of the current user (az login))
-az role assignment create --scope '/'  --role 'Owner' --assignee-object-id $(az ad signed-in-user show --query "objectId" --output tsv)
+az role assignment create --scope '/'  --role 'Owner' --assignee-object-id $(az ad signed-in-user show --query id --output tsv)
 ```
 
 PowerShell:


### PR DESCRIPTION
In $(az ad signed-in-user show --query objectId --output tsv)  "objectId" should be replaced with "id" only based on new documentation 
https://docs.microsoft.com/en-us/cli/azure/microsoft-graph-migration#breaking-changes 
otherwise, you get similar output:

admin@Azure:~$ az role assignment create --scope '/' --role 'Owner' --assignee-object-id $(az ad signed-in-user show --query objectId --output tsv) --assignee-principal-type User
WARNING: This command or command group has been migrated to Microsoft Graph API. Please carefully review all breaking changes introduced during this migration: https://docs.microsoft.com/cli/azure/microsoft-graph-migration
This command or command group has been migrated to Microsoft Graph API. Please carefully review all breaking changes introduced during this migration: https://docs.microsoft.com/cli/azure/microsoft-graph-migration
argument --assignee-object-id: expected one argument

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
