### PR TITLE
Improve deployment name uniqueness and fix vNet naming for ALZ Portal Accelerator

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -56,6 +56,15 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 
 - Release [`v2.4.1`](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/releases/tag/v2.4.1) of the Azure landing zones Terraform module adds a new diagnostic category for Azure Firewall, as reported in issue [#1063](https://github.com/Azure/Enterprise-Scale/issues/1063)
 - Update the Azure landing zone portal accelerator to use Resource Graph with a generic drop down UI element to improve user experience for subscription selection.
+- Update the Azure landing zone portal accelerator to have more unique naming for deployment names in same tenant, using `utcNow()` function in `deploymentSuffix` variable - fixes [#1077](https://github.com/Azure/Enterprise-Scale/issues/1077)
+- Update the Azure landing zone portal accelerator to have more unique naming for vNet names - fixes [#881](https://github.com/Azure/Enterprise-Scale/issues/881)
+  - vNet naming pattern changed:
+    - **From:**
+      - Identity vNet: `<Subscription ID>-<Root ID Prefix>-vnet-<Region Short Name>`
+      - Corp vNets: `<Subscription ID>-<Root ID Prefix>-vnet-<Region Short Name>`
+    - **To:**
+      - Identity vNet: `<Root ID Prefix>-vnet-<Region Short Name>-<Subscription ID>` (then trimmed to 64 characters, using `take()` function, starting at front - so Subscription ID will get trimmed)
+      - Corp vNets: `<Root ID Prefix>-vnet-<Region Short Name>-<Subscription ID>` (then trimmed to 64 characters, using `take()` function, starting at front - so Subscription ID will get trimmed)
 
 ### Policy
 

--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -65,6 +65,9 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
     - **To:**
       - Identity vNet: `<Root ID Prefix>-vnet-<Region Short Name>-<Subscription ID>` (then trimmed to 64 characters, using `take()` function, starting at front - so Subscription ID will get trimmed)
       - Corp vNets: `<Root ID Prefix>-vnet-<Region Short Name>-<Subscription ID>` (then trimmed to 64 characters, using `take()` function, starting at front - so Subscription ID will get trimmed)
+  - **⚠️This is a breaking change, only if you attempt to redeploy the Azure landing zone portal accelerator over the top of an existing Azure landing zone portal accelerator deployment that was deployed prior to 12/10/2022 (12th October 2022)⚠️**
+    - The outcome if you do this will be that new vNets will be created based on what you input into the Azure landing zone portal accelerator form when you fill it out. Even if you input exactly the same inputs and details as the first time you deployed it.
+      - However, this is a very uncommon action and if you are impacted [please raise an issue](https://github.com/Azure/Enterprise-Scale/issues) on the repo and we can assist further
 
 ### Policy
 

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -2728,7 +2728,7 @@
                         "value": "[variables('platformRgNames').identityVnetRg]"
                     },
                     "vNetName": {
-                        "value": "[concat(parameters('identitySubscriptionId'), variables('platformResourceNames').identityVnet)]"
+                        "value": "[take(concat(variables('platformResourceNames').identityVnet, '-', uniqueString(parameters('identitySubscriptionId'))), 64)]"
                     },
                     "vNetLocation": {
                         "value": "[parameters('connectivityLocation')]"
@@ -2775,7 +2775,7 @@
                         "value": "[variables('platformRgNames').identityVnetRg]"
                     },
                     "vNetName": {
-                        "value": "[concat(parameters('identitySubscriptionId'), variables('platformResourceNames').identityVnet)]"
+                        "value": "[take(concat(variables('platformResourceNames').identityVnet, '-', uniqueString(parameters('identitySubscriptionId'))), 64)]"
                     },
                     "vNetLocation": {
                         "value": "[parameters('connectivityLocation')]"
@@ -2938,7 +2938,7 @@
                         "value": "[variables('platformRgNames').lzVnetRg]"
                     },
                     "vNetName": {
-                        "value": "[concat(parameters('corpConnectedLzSubscriptionId')[copyIndex()].subs, '-', variables('platformResourceNames').lzVnet)]"
+                        "value": "[take(concat(variables('platformResourceNames').lzVnet, '-', parameters('corpConnectedLzSubscriptionId')[copyIndex()].subs), 64)]"
                     },
                     "vNetLocation": {
                         "value": "[parameters('connectivityLocation')]"
@@ -2995,7 +2995,7 @@
                         "value": "[variables('platformRgNames').lzVnetRg]"
                     },
                     "vNetName": {
-                        "value": "[concat(parameters('corpConnectedLzSubscriptionId')[copyIndex()].subs, '-', variables('platformResourceNames').lzVnet)]"
+                        "value": "[take(concat(variables('platformResourceNames').lzVnet, '-', parameters('corpConnectedLzSubscriptionId')[copyIndex()].subs), 64)]"
                     },
                     "vNetLocation": {
                         "value": "[parameters('connectivityLocation')]"

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -653,6 +653,13 @@
             "metadata": {
                 "description": "Configure the count of empty deployments used to introduce a delay after policy deployment. Used to increase reliability of deployment, but can be reduced when re-deploying to an existing environment."
             }
+        },
+        "currentDateTimeUtcNow": {
+            "type": "string",
+            "defaultValue": "[utcNow()]",
+            "metadata": {
+                "description": "The current date and time using the utcNow function. Used for deployment name uniqueness"
+            }
         }
     },
     "variables": {
@@ -731,7 +738,7 @@
             "govMdfcPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/gov/fairfaxDINE-MDFCConfigPolicyAssignment.json')]"
         },
         // Declaring deterministic deployment names
-        "deploymentSuffix": "[concat('-', deployment().location, '-', guid(parameters('enterpriseScaleCompanyPrefix')))]",
+        "deploymentSuffix": "[concat('-', deployment().location, '-', guid(parameters('enterpriseScaleCompanyPrefix'), parameters('currentDateTimeUtcNow')))]",
         "deploymentNames": {
             "mgmtGroupDeploymentName": "[take(concat('alz-Mgs', variables('deploymentSuffix')), 64)]",
             "mgmtSubscriptionPlacement": "[take(concat('alz-MgmtSub', variables('deploymentSuffix')), 64)]",
@@ -790,7 +797,7 @@
             "identityPeeringDeploymentName": "[take(concat('alz-IDPeering', variables('deploymentSuffix')), 64)]",
             "identityVwanPeeringDeploymentName": "[take(concat('alz-IDVwanPeering', variables('deploymentSuffix')), 64)]",
             "corpConnectedLzVwanSubs": "[take(concat('alz-CorpConnLzsVwan', variables('deploymentSuffix')), 50)]",
-            "pidCuaDeploymentName": "[take(concat('pid-', variables('cuaid'), '-' , uniqueString(deployment().location, parameters('enterpriseScaleCompanyPrefix'))), 64)]"
+            "pidCuaDeploymentName": "[take(concat('pid-', variables('cuaid'), '-' , uniqueString(deployment().location, parameters('enterpriseScaleCompanyPrefix'), parameters('currentDateTimeUtcNow'))), 64)]"
         },
         "esLiteDeploymentNames": {
             "mgmtGroupLiteDeploymentName": "[take(concat('alz-MgsLite', variables('deploymentSuffix')), 64)]",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR improves deployment name uniqueness, as per #1077, and fixes vNet naming for ALZ Portal Accelerator, as per #881.

## This PR fixes/adds/changes/removes

1. Fixes #1077 - FYI @JefferyMitchell 
2. Fixes #881 

### Breaking Changes

vNet naming pattern changed:
- **From:**
  - Identity vNet: `<Subscription ID>-<Root ID Prefix>-vnet-<Region Short Name>`
  - Corp vNets: `<Subscription ID>-<Root ID Prefix>-vnet-<Region Short Name>`
- **To:**
  - Identity vNet: `<Root ID Prefix>-vnet-<Region Short Name>-<Subscription ID>` (then trimmed to 64 characters, using `take()` function, starting at front - so Subscription ID will get trimmed)
  - Corp vNets: `<Root ID Prefix>-vnet-<Region Short Name>-<Subscription ID>` (then trimmed to 64 characters, using `take()` function, starting at front - so Subscription ID will get trimmed)
- **⚠️This is a breaking change, only if you attempt to redeploy the Azure landing zone portal accelerator over the top of an existing Azure landing zone portal accelerator deployment that was deployed prior to 12/10/2022 (12th October 2022)⚠️** (hopefully when we will merge)
- The outcome if you do this will be that new vNets will be created based on what you input into the Azure landing zone portal accelerator form when you fill it out. Even if you input exactly the same inputs and details as the first time you deployed it.
  - However, this is a very uncommon action and if you are impacted [please raise an issue](https://github.com/Azure/Enterprise-Scale/issues) on the repo and we can assist further

## Testing Evidence

Deployed to Sweeden Central to try to reproduce error in #881 and unable to 👍, therefore working.

![image](https://user-images.githubusercontent.com/41163455/195184799-2874729a-4fb0-4e08-8ead-9ed2940e228a.png)

![image](https://user-images.githubusercontent.com/41163455/195184815-210fa94d-d40e-49e4-9daa-7510a0cee53b.png)

![image](https://user-images.githubusercontent.com/41163455/195184824-96daf0d2-d2d2-4abe-b4d7-f7cb89f9f35a.png)

![image](https://user-images.githubusercontent.com/41163455/195184839-37ca39f0-15aa-4696-884f-aee5155e6a9c.png)

### Testing URLs

#### Azure Public

[![Deploy To Azure](https://docs.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjtracey93%2FEnterprise-Scale%2Ffix-naming-deployments-vnets%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fjtracey93%2FEnterprise-Scale%2Ffix-naming-deployments-vnets%2FeslzArm%2Feslz-portal.json)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
