### PR TITLE
Update workflows to fix permissions error

### DIFF
--- a/.github/workflows/test-portal.yml
+++ b/.github/workflows/test-portal.yml
@@ -9,10 +9,10 @@ name: Test Portal Experience
 on:
   pull_request_target:
     types:
-      - edited
       - opened
       - reopened
       - synchronize
+      - ready_for_review
     paths:
       - "eslzArm/**.json"
       - "src/**.json"

--- a/.github/workflows/update-portal.yml
+++ b/.github/workflows/update-portal.yml
@@ -9,10 +9,10 @@ name: Update Portal Experience
 on:
   pull_request_target:
     types:
-      - edited
       - opened
       - reopened
       - synchronize
+      - ready_for_review
 
 env:
   github_user_name: 'github-actions'
@@ -87,7 +87,7 @@ jobs:
 
               echo "==> Push changes..."
               echo "Pushing changes to: $github_pr_repo"
-              git push "https://$GITHUB_TOKEN@github.com/$github_pr_repo.git"
+              git push "https://$GITHUB_TOKEN@github.com/$github_pr_repo.git" "HEAD:$GITHUB_BASE_REF"
 
           else
               echo "No changes found."

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           mapfile -t CHECK_GIT_STATUS < <(git status -s)
           printf "%s\n" "${CHECK_GIT_STATUS[@]}"
-          echo "::set-output name=changes::${#CHECK_GIT_STATUS[@]}"
+          echo "changes=${#CHECK_GIT_STATUS[@]}" >> $GITHUB_OUTPUT
         working-directory: ${{ env.wiki_target_repo }}
 
       - name: Add files, commit and push into Wiki

--- a/eslzArm/managementGroupTemplates/policyDefinitions/policies.json
+++ b/eslzArm/managementGroupTemplates/policyDefinitions/policies.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.10.61.36676",
-      "templateHash": "12718734228119532752"
+      "version": "0.11.1.770",
+      "templateHash": "12625835499431513826"
     }
   },
   "parameters": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Fix set-output deprecation as documented in [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
2. Update triggers to improve workflow behaviour
3. Fixes the issue observed in PR #1059 

![image](https://user-images.githubusercontent.com/12268562/197142779-80d1be48-6b59-4762-9621-baf0a17665b4.png)

### Breaking Changes

none

## Testing Evidence

n/a

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
