### PR TITLE
Fix multiline input for `Edit-LineEndings` function

### DIFF
--- a/src/Alz.Tools/functions/Alz.Tools.ps1
+++ b/src/Alz.Tools/functions/Alz.Tools.ps1
@@ -264,7 +264,7 @@ function Edit-LineEndings {
 
     Process {
 
-        [String[]]$outputText = $InputText |
+        [String[]]$outputText += $InputText |
         ForEach-Object { $_ -replace "`r`n", "`n" } |
         ForEach-Object { $_ -replace "`r", "`n" } |
         ForEach-Object { $_ -replace "`n", "$eol" }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fix multiline input for `Edit-LineEndings` function

## This PR fixes/adds/changes/removes

1. Fix `Edit-LineEndings` function to ensure correct handling of `[string[]]` input

### Breaking Changes

n/a

## Testing Evidence

n/a

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
