### PR TITLE
US 24400 - Links to superseded policies

### DIFF
--- a/docs/wiki/ALZ-Deprecated-Services.md
+++ b/docs/wiki/ALZ-Deprecated-Services.md
@@ -21,6 +21,6 @@ Over time, a deprecation process of there `ALZ / custom` policies will have to t
 
 | Deprecated ALZ Policy IDs                     | Superseded by built-in policy IDs    | Justification                                                            |
 |-----------------------------------------------|--------------------------------------|--------------------------------------------------------------------------|
-| Deploy-Nsg-FlowLogs | e920df7f-9a64-4066-9b58-52684c02a091 | Custom policy replaced by built-in requires less administration overhead |
-| Deploy-Nsg-FlowLogs-to-LA | e920df7f-9a64-4066-9b58-52684c02a091 | Custom policy replaced by built-in requires less administration overhead |
-| Deny-PublicIP | 6c112d4e-5bc7-47ae-a041-ea2d9dccd749 | Custom policy replaced by built-in requires less administration overhead |½
+| Deploy-Nsg-FlowLogs | [e920df7f-9a64-4066-9b58-52684c02a091](https://www.azadvertizer.net/azpolicyadvertizer/e920df7f-9a64-4066-9b58-52684c02a091.html?) | Custom policy replaced by built-in requires less administration overhead |
+| Deploy-Nsg-FlowLogs-to-LA | [e920df7f-9a64-4066-9b58-52684c02a091](https://www.azadvertizer.net/azpolicyadvertizer/e920df7f-9a64-4066-9b58-52684c02a091.html?) | Custom policy replaced by built-in requires less administration overhead |
+| Deny-PublicIP | [6c112d4e-5bc7-47ae-a041-ea2d9dccd749](https://www.azadvertizer.net/azpolicyadvertizer/6c112d4e-5bc7-47ae-a041-ea2d9dccd749.html?) | Custom policy replaced by built-in requires less administration overhead |½

--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -54,6 +54,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 - Renamed Azure DDoS Standard Protection references to [Azure DDoS Network Protection](https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-sku-comparison#ddos-network-protection).
 - Added ALZ deprecated [policies section](Deprecating-ALZ-Policies.md) to the Wiki.
 - Included documentation on how to [Migrate ALZ custom policies to Azure builtin policies](migrate-alz-policies-to-builtin.md) to the Wiki.
+- Added links to the superseding policies on the [ALZ Deprecated Services](./ALZ-Deprecated-Services.md) page.
 
 #### Tooling
 

--- a/eslzArm/managementGroupTemplates/policyDefinitions/policies.json
+++ b/eslzArm/managementGroupTemplates/policyDefinitions/policies.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.11.1.770",
-      "templateHash": "2668983956432950386"
+      "version": "0.12.40.16777",
+      "templateHash": "1128074064579089044"
     }
   },
   "parameters": {


### PR DESCRIPTION
## Overview/Summary

As well as policy IDs that supersede the ALZ Custom policies, there is now a link to AzAdvertizer of the superseded policy. 

## This PR fixes/adds/changes/removes

1. Adds links to the superseded policies

### Breaking Changes

1. N/A

## Testing Evidence

N/A

### Testing URLs

#### Azure Public

[![Deploy To Azure](https://docs.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Flinkstopolicies%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Flinkstopolicies%2FeslzArm%2Feslz-portal.json)

#### Azure US Gov (Fairfax)
[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Flinkstopolicies%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Flinkstopolicies%2FeslzArm%2Ffairfaxeslz-portal.json)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
- [X] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
