### PR TITLE
Use -SignedIn to get current user

### DIFF
--- a/docs/wiki/Deploying-ALZ-Pre-requisites.md
+++ b/docs/wiki/Deploying-ALZ-Pre-requisites.md
@@ -47,7 +47,7 @@ Powershell:
 Connect-AzAccount
 
 #get object Id of  the current user (that is used above)
-$user = Get-AzADUser -UserPrincipalName (Get-AzContext).Account
+$user = Get-AzAduser -SignedIn
 
 #assign Owner  role to Tenant root scope ("/") as a User Access Administrator
 New-AzRoleAssignment -Scope '/' -RoleDefinitionName 'Owner' -ObjectId $user.Id


### PR DESCRIPTION
The previous code example does not work if you use
- External accounts (f.eg GitHub login)
- Cloud Shell (Context account is `MSI@nnnn`, not your identity)

Using `Get-AzAduser -SignedIn` works in most cases as it uses the /me endpoint to get connected user.