### PR TITLE
ALZ Contribution Guide - Policy Naming Convention

### DIFF
--- a/docs/wiki/ALZ-Contribution-Guide.md
+++ b/docs/wiki/ALZ-Contribution-Guide.md
@@ -93,6 +93,24 @@ To work with policies, they are location in [src/resources/Microsoft.Authorizati
 
 To create a new policy, it is worth taking the framework from an already existing policy.
 
+In ALZ Custom there is a way to name the custom policies that are used. They are prefixed with one of the following: `Append`, `Audit`, `Deny` or `Deploy`
+
+#### Append
+
+When contributing a custom policy based on appending resources at scale, the correct prefix would be `Append` - such as `Append-AppService-httpsonly.json`.
+
+#### Audit
+
+Auditing resources at scale via policy is achievable using the correct effect inside the definition. This policy contribution should be prefixed with `Audit` - in example, `Audit-MachineLearning-PrivateEndpointId.json`. 
+
+#### Deny
+
+Deny policies are used to prevent the creation/action of and on Azure resources. Policies being created and contributed should be prefixed with 'Deny' - in example `Deny-Databricks-Sku.json`.
+
+#### Deploy
+
+Deploy follows the DeployIfNotExists (DINE) methodology. Policy contribution should be named prefixed with `Deploy` - in example `Deploy-Custom-Route-Table.json`. 
+
 Inside of the JSON is a `metadata` section which is required for policy creation.
 
 ![Policy Metadata](https://github.com/Azure/Enterprise-Scale/blob/main/docs/wiki/media/policy-metadata-example.png)

--- a/docs/wiki/ALZ-Contribution-Guide.md
+++ b/docs/wiki/ALZ-Contribution-Guide.md
@@ -95,23 +95,27 @@ To create a new policy, it is worth taking the framework from an already existin
 
 In ALZ Custom there is a way to name the custom policies that are used. They are prefixed with one of the following: `Append`, `Audit`, `Deny` or `Deploy`
 
-#### Append
+#### **Append**
 
 When contributing a custom policy based on appending resources at scale, the correct prefix would be `Append` - such as `Append-AppService-httpsonly.json`.
 
-#### Audit
+#### **Audit**
 
 Auditing resources at scale via policy is achievable using the correct effect inside the definition. This policy contribution should be prefixed with `Audit` - in example, `Audit-MachineLearning-PrivateEndpointId.json`. 
 
-#### Deny
+#### **Deny**
 
 Deny policies are used to prevent the creation/action of and on Azure resources. Policies being created and contributed should be prefixed with 'Deny' - in example `Deny-Databricks-Sku.json`.
 
-#### Deploy
+#### **Deploy**
 
 Deploy follows the DeployIfNotExists (DINE) methodology. Policy contribution should be named prefixed with `Deploy` - in example `Deploy-Custom-Route-Table.json`. 
 
-> NOTE: When creating the naming convention for the definition, it must company with the [Naming rule and restrictions for Azure resources | Microsoft Authorization](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftauthorization) standard.
+The naming convetion should be formatted in the following manner: `{prefix}-{resourceType}-{targetSetting}.json`.  In an example: `Deny-SqlMi-minTLS.json`.
+
+When creating the naming convention for the definition, it must company with the [Naming rule and restrictions for Azure resources | Microsoft Authorization](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftauthorization) standard.
+
+Once the `Name` in the file name and `Name` in the policy definition have been set, it is worth noting that they should not be changed as it can impact initiatives and assignments.
 
 Inside of the JSON is a `metadata` section which is required for policy creation.
 

--- a/docs/wiki/ALZ-Contribution-Guide.md
+++ b/docs/wiki/ALZ-Contribution-Guide.md
@@ -111,6 +111,8 @@ Deny policies are used to prevent the creation/action of and on Azure resources.
 
 Deploy follows the DeployIfNotExists (DINE) methodology. Policy contribution should be named prefixed with `Deploy` - in example `Deploy-Custom-Route-Table.json`. 
 
+> NOTE: When creating the naming convention for the definition, it must company with the [Naming rule and restrictions for Azure resources | Microsoft Authorization](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftauthorization) standard.
+
 Inside of the JSON is a `metadata` section which is required for policy creation.
 
 ![Policy Metadata](https://github.com/Azure/Enterprise-Scale/blob/main/docs/wiki/media/policy-metadata-example.png)


### PR DESCRIPTION
## Overview/Summary

Updated Contribution Guidance for policy contribution naming convention.

AB #23845

## This PR fixes/adds/changes/removes

1. Updates the Contribution Guidance for policy naming convention

### Breaking Changes

1. N/A

## Testing Evidence

N/A

### Testing URLs

The below URLs can be updated where the placeholders are, look for `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}` & `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}`, to allow you to test your portal deployment experience.

> Please also replace the curly brackets on the placeholders `{}`

#### Azure Public

[![Deploy To Azure](https://docs.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Fpolicycontributionguidance%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Fpolicycontributionguidance%2FeslzArm%2Feslz-portal.json)

#### Azure US Gov (Fairfax)
[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Fpolicycontributionguidance%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FJamJarchitect%2FEnterprise-Scale%2Fpolicycontributionguidance%2FeslzArm%2Ffairfaxeslz-portal.json)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [X] Performed testing and provided evidence.
- [X] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [X] Updated relevant and associated documentation.
- [X] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
