### PR TITLE
fix: Update MG location parameter name

### DIFF
--- a/docs/wiki/Update-ALZ-Custom-Policies-to-Latest.md
+++ b/docs/wiki/Update-ALZ-Custom-Policies-to-Latest.md
@@ -243,7 +243,7 @@ For this scenario we will use the ALZ custom initiative _Deploy Diagnostic Setti
         if ($policyDefId -match '(\/\w+\/\w+\.\w+\/\w+\/)(\w+)(\/.+)') {
           $policyDefinitionName = $policyDefId.substring($policyDefId.lastindexof('/') + 1)
           $policyDefinitionPath = "./$($policyDefinitionName).json"
-          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/Enterprise-Scale/main/src/resources/Microsoft.Authorization/policyDefinitions/$($policyDefinitionName).json" -OutFile $policyDefinitionPath
+          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/Enterprise-Scale/main/src/resources/Microsoft.Authorization/policyDefinitions/$($policyDefinitionName).json" -OutFile $policySetDefinitionPath
           $policyDef = Get-Content $policyDefinitionPath | ConvertFrom-Json -Depth 100
           $policyName = $policyDef.name
           $displayName = $policyDef.properties.displayName
@@ -253,7 +253,7 @@ For this scenario we will use the ALZ custom initiative _Deploy Diagnostic Setti
           $parameters = $policyDef.properties.parameters | ConvertTo-Json -Depth 100
           $policyRule = $policyDef.properties.policyRule | ConvertTo-Json -Depth 100
           $policyRule = $policyRule.Replace('[[', '[')
-          New-AzPolicyDefinition -Name $policyName -DisplayName $displayname -Description $description -Policy $policyRule -Mode $mode -Metadata $metadata -Parameter $parameters -ManagementGroupName $policyDefinitionLocation
+          New-AzPolicyDefinition -Name $policyName -DisplayName $displayname -Description $description -Policy $policyRule -Mode $mode -Metadata $metadata -Parameter $parameters -ManagementGroupName $policySetDefinitionLocation
         }
       }
     }
@@ -266,8 +266,8 @@ For this scenario we will use the ALZ custom initiative _Deploy Diagnostic Setti
   $parameters = $policySetDef.properties.parameters | ConvertTo-Json -Depth 100
   $policyDefinitions = ConvertTo-Json -InputObject @($policySetDef.properties.policyDefinitions) -Depth 100
   $policyDefinitions = $policyDefinitions.Replace('[[', '[')
-  $policyDefinitions = $policyDefinitions -replace '(\/\w+\/\w+\.\w+\/\w+\/)(\w+)(\/.+)', "`${1}$policyDefinitionLocation`${3}"
-  New-AzPolicySetDefinition -Name $policyName -DisplayName $displayname -Description $description -PolicyDefinition $policyDefinitions -Metadata $metadata -Parameter $parameters -ManagementGroupName $policyDefinitionLocation
+  $policyDefinitions = $policyDefinitions -replace '(\/\w+\/\w+\.\w+\/\w+\/)(\w+)(\/.+)', "`${1}$policySetDefinitionLocation`${3}"
+  New-AzPolicySetDefinition -Name $policyName -DisplayName $displayname -Description $description -PolicyDefinition $policyDefinitions -Metadata $metadata -Parameter $parameters -ManagementGroupName $policySetDefinitionLocation
   ```
 
 > Note that if you decide on another approach from the script above, there are a number of double square brackets ('[[') in the file. These need to be replaced with single square brackets before the policy set definition is valid syntax.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Some bug fix for the code example in the **Update ALZ Custom Policies to Latest** WIKI article.

## This PR fixes/adds/changes/removes

1. For the last code example in the Wiki article, uses the correct POSH parameter name, $policySetDefinitionLocation

### Breaking Changes

N/A

## Testing Evidence

Validated code by running it in my lab to update Deploy-MDFC-Config policy initiative.

### Testing URLs

N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
