### PR TITLE
Bug - Fix case for azureIotPrivateDnsZoneId parameter in policy assignment

### DIFF
--- a/eslzArm/managementGroupTemplates/policyAssignments/DINE-PrivateDNSZonesPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DINE-PrivateDNSZonesPolicyAssignment.json
@@ -234,7 +234,7 @@
                     "azureAsrPrivateDnsZoneId": {
                         "value": "[variables('policyParameterMapping').azureAsrPrivateDnsZoneId]"
                     },
-                    "azureIoTPrivateDnsZoneId": {
+                    "azureIotPrivateDnsZoneId": {
                         "value": "[variables('policyParameterMapping').azureIotPrivateDnsZoneId]"
                     },
                     "azureKeyVaultPrivateDnsZoneId": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The casing of the parameter was causing an idempotency issue in the downstream Terraform module, which is case sensitive.

## This PR fixes/adds/changes/removes

will eventually fix Azure/terraform-azurerm-caf-enterprise-scale#699

### Breaking Changes

None

## Testing Evidence

N/A

### Testing URLs

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjaredfholgate%2FEnterprise-Scale%2Fbug-fix-policy-assignment-parameter-casing%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fjaredfholgate%2FEnterprise-Scale%2Fbug-fix-policy-assignment-parameter-casing%2FeslzArm%2Feslz-portal.json)

#### Azure US Gov (Fairfax)
[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjaredfholgate%2FEnterprise-Scale%2Fbug-fix-policy-assignment-parameter-casing%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fjaredfholgate%2FEnterprise-Scale%2Fbug-fix-policy-assignment-parameter-casing%2FeslzArm%2Ffairfaxeslz-portal.json)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
