### PR TITLE
Fix: Wiki ALZ Azure Setup Bash command

### DIFF
--- a/docs/wiki/ALZ-Setup-azure.md
+++ b/docs/wiki/ALZ-Setup-azure.md
@@ -41,7 +41,7 @@ az role assignment create --scope '/' --role 'Owner' --assignee-object-id $(az a
 
 #(optional) assign Owner role at Tenant root scope ("/") as a User Access Administrator to service principal (set spn_displayname to your service principal displayname)
 spn_displayname='<ServicePrincipal DisplayName>'
-az role assignment create --scope '/' --role 'Owner' --assignee-object-id $(az ad sp list --display-name $spn_displayname --query '[].{objectId:objectId}' -o tsv) --assignee-principal-type ServicePrincipal
+az role assignment create --scope '/' --role 'Owner' --assignee-object-id $(az ad sp list --display-name "$spn_displayname" --query '[].id' -o tsv) --assignee-principal-type ServicePrincipal
 ````
 
 PowerShell

--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -1,6 +1,7 @@
 ## In this Section
 
 - [Updates](#updates)
+  - [November 2023](#november-2023)
   - [October 2023](#october-2023)
   - [September 2023](#september-2023)
   - [August 2023](#august-2023)
@@ -38,6 +39,11 @@ This article will be updated as and when changes are made to the above and anyth
 ## Updates
 
 Here's what's changed in Enterprise Scale/Azure Landing Zones:
+
+### November 2023
+
+#### Docs
+- Fixed in ALZ Azure Setup the bash command to assign at root scope _Owner_ role to a Service Principal.
 
 ### October 2023
 


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
The Azure CLI command that assigns _Owner_ role on the Tenant root to the Service Principal is not working.

## This PR fixes/adds/changes/removes

Fix the command to assign Owner role to the Service Principal.

### Breaking Changes

None

## Testing Evidence

![image](https://github.com/Azure/Enterprise-Scale/assets/26668031/cf2f39d3-2959-43ad-a538-c133fbf0e7b3)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [ ] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
