### PR TITLE
vWAN with single subscription deployment bug fix

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -46,6 +46,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 
 - Added virtual hub routing preference support to Portal Accelerator for scenarios where you need to influence routing decisions in virtual hub router towards on-premises. For existing ALZ customers please visit [Configure virtual hub routing preference](https://learn.microsoft.com/azure/virtual-wan/howto-virtual-hub-routing-preference) for details on how to configure virtual hub routing preference settings.
 - Added virtual hub capacity option to Portal Accelerator which provides an option to select the number of routing infrastracture units. Please visit [Virtual hub capacity](https://learn.microsoft.com/azure/virtual-wan/hub-settings#capacity) for more details on Azure vWAN Virtual Hub Capacity configuration.
+- Fixed a bug in the portal accelerator experience when deploying with single platform subscription and selecting virtual WAN networking topology - Invalid Template error.
 
 #### Docs
 - Fixed in ALZ Azure Setup the bash command to assign at root scope _Owner_ role to a Service Principal.

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -4395,6 +4395,21 @@
                     },
                     "vpnGateWayScaleUnit": {
                         "value": "[parameters('vpnGateWayScaleUnit')]"
+                    },
+                    "enablevWANRoutingIntent":{
+                        "value":"[parameters('enablevWANRoutingIntent')]"
+                    },
+                    "internetTrafficRoutingPolicy":{
+                        "value":"[parameters('internetTrafficRoutingPolicy')]"
+                    },
+                    "privateTrafficRoutingPolicy":{
+                        "value":"[parameters('privateTrafficRoutingPolicy')]"
+                    },
+                    "vWANHubRoutingPreference":{
+                        "value":"[parameters('vWANHubRoutingPreference')]"
+                    },
+                    "vWanHubCapacity":{
+                        "value":"[parameters('vWANHubCapacity')]"
                     }
                 }
             }


### PR DESCRIPTION
## Overview/Summary

Fixed a bug in the portal accelerator experience when deploying with single platform subscription and selecting virtual WAN networking topology - Invalid Template error. Added missing parameters for recently introduced vWAN Hub features into ES Lite Only deployment for vWAN.

GitHub Issue: Bug Report Deployment template validation fails when selecting Virtual WAN and single subscription #1470

## This PR fixes/adds/changes/removes

1. Updated `eslzArm.json`

### Breaking Changes

1. N/A

## Testing Evidence

![image](https://github.com/Azure/Enterprise-Scale/assets/72864397/b3688ed5-f142-48e2-95f7-8430318480d4)
![image](https://github.com/Azure/Enterprise-Scale/assets/72864397/2b4c2f98-a6d4-49b5-a893-ae71fdb81c71)
![image](https://github.com/Azure/Enterprise-Scale/assets/72864397/8bf6e0a3-f786-4dcb-8aab-a7928122159d)
![image](https://github.com/Azure/Enterprise-Scale/assets/72864397/16677d3d-b93d-4e55-bcd3-6a48982eb9e7)


### Testing URLs

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frozkurt%2FEnterprise-Scale-rozkurt%2FvWAN_with_Single_Subscription_Deployment_Bug_Fix%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Frozkurt%2FEnterprise-Scale-rozkurt%2FvWAN_with_Single_Subscription_Deployment_Bug_Fix%2FeslzArm%2Feslz-portal.json)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
