### PR TITLE
Fix for #1565: pass `userAssignedIdentityResourceGroup` to deployment

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -44,6 +44,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 #### Tooling
 
 - Disabled a Policy in the Microsoft Defender for SQL initiative. As it is not required at this stage. See [ALZ AMA FAQ](./ALZ-AMA-FAQ) for more details.
+- Bug fix for Portal Accelerator. userAssignedIdentityResourceGroup has been added as output for the Portal UI, this fixes deploying the Resource Group with a custom name.
 
 ### AMA Update for the Portal Accelerator
 

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -3971,7 +3971,8 @@
                 "auditAppGwWaf": "[steps('landingZones').lzSection.auditAppGwWaf]",
                 "enforceAcsb": "[steps('landingZones').lzSection.enforceAcsb]",
                 "enableDecommissioned": "[steps('decommissionedSandboxZones').decommSection.enableDecommissioned]",
-                "enableSandbox": "[steps('decommissionedSandboxZones').sandboxSection.enableSandbox]"
+                "enableSandbox": "[steps('decommissionedSandboxZones').sandboxSection.enableSandbox]",
+                "userAssignedIdentityResourceGroup": "[steps('management').userAssignedIdentityResourceGroup"
             },
             "kind": "Tenant",
             "location": "[steps('basics').resourceScope.location.name]"

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -3972,7 +3972,7 @@
                 "enforceAcsb": "[steps('landingZones').lzSection.enforceAcsb]",
                 "enableDecommissioned": "[steps('decommissionedSandboxZones').decommSection.enableDecommissioned]",
                 "enableSandbox": "[steps('decommissionedSandboxZones').sandboxSection.enableSandbox]",
-                "userAssignedIdentityResourceGroup": "[steps('management').userAssignedIdentityResourceGroup"
+                "userAssignedIdentityResourceGroup": "[steps('management').userAssignedIdentityResourceGroup]"
             },
             "kind": "Tenant",
             "location": "[steps('basics').resourceScope.location.name]"


### PR DESCRIPTION
## Overview/Summary

Add `userAssignedIdentityResourceGroup` as output for the Portal UI

## This PR fixes/adds/changes/removes

1. #1565

### Breaking Changes

N/A

## Testing Evidence

N/A

### Testing URLs

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSvenAelterman%2FEnterprise-Scale%2FSvenAelterman-patch-1%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FSvenAelterman%2FEnterprise-Scale%2FSvenAelterman-patch-1%2FeslzArm%2Feslz-portal.json)

#### Azure US Gov (Fairfax)
[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSvenAelterman%2FEnterprise-Scale%2FSvenAelterman-patch-1%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FSvenAelterman%2FEnterprise-Scale%2FSvenAelterman-patch-1%2FeslzArm%2Ffairfaxeslz-portal.json)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
