### PR TITLE
Fixes 1570 portal deployment issue

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -46,6 +46,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 - Disabled a Policy in the Microsoft Defender for SQL initiative. As it is not required at this stage. See [ALZ AMA FAQ](./ALZ-AMA-FAQ) for more details.
 - Changed enforcementMode of the assignment of Policy "Deploy-UserAssignedManagedIdentity-VMInsights" to Default. This is to ensure that a Resource Group and a User Assigned Managed Identity are created on new subscriptions (subscriptions that are added after the initial deployment).
 - Bug fix for Portal Accelerator. userAssignedIdentityResourceGroup has been added as output for the Portal UI, this fixes deploying the Resource Group with a custom name.
+- Bug fix for Portal Accelerator. `subscriptionIds` now uses lambda function to obtain the subscription IDs from `corpConnectedLzSubscriptionId`. This fixes the Invalid Template error when selecting a corp connected landing zone deployment.
 
 ### AMA Update for the Portal Accelerator
 

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1209,7 +1209,8 @@
         },
         "privateDnsZonesMerge": "[if(and(contains(variables('azBackupGeoCodes'), parameters('connectivityLocation')), contains(variables('privateDnsZones'), 'privatelink.regionGeoShortCode.backup.windowsazure.com')), union(createArray(replace(variables('privateDnsZones')[0], '.regionGeoShortCode.', concat('.', variables('azBackupGeoCodes')[toLower(parameters('connectivityLocation'))], '.'))), variables('privateDnsZones')), variables('privateDnsZones'))]",
         "privateDnsZonesMergedWithBackupPlaceholderRemoved": "[filter(variables('privateDnsZonesMerge'), lambda('i', not(equals(lambdaVariables('i'), 'privatelink.regionGeoShortCode.backup.windowsazure.com'))))]",
-        "subscriptionIds": "[union(parameters('onlineLzSubscriptionId'), parameters('corpLzSubscriptionId'), parameters('corpConnectedLzSubscriptionId').subs, if(empty(parameters('singlePlatformSubscriptionId')), createArray(parameters('managementSubscriptionId'), parameters('connectivitySubscriptionId'), parameters('identitySubscriptionId')), createArray(parameters('singlePlatformSubscriptionId'))))]",
+        "corpConnectedLzSubscriptionIds": "[parameters('corpConnectedLzSubscriptionId').subs]",
+        "subscriptionIds": "[union(parameters('onlineLzSubscriptionId'), parameters('corpLzSubscriptionId'), variables('corpConnectedLzSubscriptionIds'), if(empty(parameters('singlePlatformSubscriptionId')), createArray(parameters('managementSubscriptionId'), parameters('connectivitySubscriptionId'), parameters('identitySubscriptionId')), createArray(parameters('singlePlatformSubscriptionId'))))]",
         "roleDefinitions": {
             "networkContributor": "4d97b98b-1d4f-4787-a291-c67834d212e7"
         },
@@ -1692,7 +1693,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[concat(variables('deploymentNames').userAssignedIdentityRgDeploymentName, copyIndex())]",
-            "subscriptionId": "[string(variables('subscriptionIds')[copyIndex()])]",
+            "subscriptionId": "[variables('subscriptionIds')[copyIndex()]]",
             "location": "[deployment().location]",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('deploymentNames').mgmtSubscriptionPlacement)]",
@@ -1730,7 +1731,7 @@
             "apiVersion": "2020-10-01",
             "name": "[concat(variables('deploymentNames').userAssignedIdentityDeploymentName, copyIndex())]",
             "location": "[deployment().location]",
-            "subscriptionId": "[string(variables('subscriptionIds')[copyIndex()])]",
+            "subscriptionId": "[variables('subscriptionIds')[copyIndex()]]",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('deploymentNames').monitoringDeploymentName)]",
                 "userAssignedIdentityRg"

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1692,7 +1692,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[concat(variables('deploymentNames').userAssignedIdentityRgDeploymentName, copyIndex())]",
-            "subscriptionId": "[variables('subscriptionIds')[copyIndex()]]",
+            "subscriptionId": "[string(variables('subscriptionIds')[copyIndex()])]",
             "location": "[deployment().location]",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('deploymentNames').mgmtSubscriptionPlacement)]",

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1209,7 +1209,7 @@
         },
         "privateDnsZonesMerge": "[if(and(contains(variables('azBackupGeoCodes'), parameters('connectivityLocation')), contains(variables('privateDnsZones'), 'privatelink.regionGeoShortCode.backup.windowsazure.com')), union(createArray(replace(variables('privateDnsZones')[0], '.regionGeoShortCode.', concat('.', variables('azBackupGeoCodes')[toLower(parameters('connectivityLocation'))], '.'))), variables('privateDnsZones')), variables('privateDnsZones'))]",
         "privateDnsZonesMergedWithBackupPlaceholderRemoved": "[filter(variables('privateDnsZonesMerge'), lambda('i', not(equals(lambdaVariables('i'), 'privatelink.regionGeoShortCode.backup.windowsazure.com'))))]",
-        "subscriptionIds": "[union(parameters('onlineLzSubscriptionId'), parameters('corpLzSubscriptionId'), parameters('corpConnectedLzSubscriptionId'), if(empty(parameters('singlePlatformSubscriptionId')), createArray(parameters('managementSubscriptionId'), parameters('connectivitySubscriptionId'), parameters('identitySubscriptionId')), createArray(parameters('singlePlatformSubscriptionId'))))]",
+        "subscriptionIds": "[union(parameters('onlineLzSubscriptionId'), parameters('corpLzSubscriptionId'), parameters('corpConnectedLzSubscriptionId').subs, if(empty(parameters('singlePlatformSubscriptionId')), createArray(parameters('managementSubscriptionId'), parameters('connectivitySubscriptionId'), parameters('identitySubscriptionId')), createArray(parameters('singlePlatformSubscriptionId'))))]",
         "roleDefinitions": {
             "networkContributor": "4d97b98b-1d4f-4787-a291-c67834d212e7"
         },

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1730,7 +1730,7 @@
             "apiVersion": "2020-10-01",
             "name": "[concat(variables('deploymentNames').userAssignedIdentityDeploymentName, copyIndex())]",
             "location": "[deployment().location]",
-            "subscriptionId": "[variables('subscriptionIds')[copyIndex()]]",
+            "subscriptionId": "[string(variables('subscriptionIds')[copyIndex()])]",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('deploymentNames').monitoringDeploymentName)]",
                 "userAssignedIdentityRg"

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1209,8 +1209,7 @@
         },
         "privateDnsZonesMerge": "[if(and(contains(variables('azBackupGeoCodes'), parameters('connectivityLocation')), contains(variables('privateDnsZones'), 'privatelink.regionGeoShortCode.backup.windowsazure.com')), union(createArray(replace(variables('privateDnsZones')[0], '.regionGeoShortCode.', concat('.', variables('azBackupGeoCodes')[toLower(parameters('connectivityLocation'))], '.'))), variables('privateDnsZones')), variables('privateDnsZones'))]",
         "privateDnsZonesMergedWithBackupPlaceholderRemoved": "[filter(variables('privateDnsZonesMerge'), lambda('i', not(equals(lambdaVariables('i'), 'privatelink.regionGeoShortCode.backup.windowsazure.com'))))]",
-        "corpConnectedLzSubscriptionIds": "[parameters('corpConnectedLzSubscriptionId').subs]",
-        "subscriptionIds": "[union(parameters('onlineLzSubscriptionId'), parameters('corpLzSubscriptionId'), variables('corpConnectedLzSubscriptionIds'), if(empty(parameters('singlePlatformSubscriptionId')), createArray(parameters('managementSubscriptionId'), parameters('connectivitySubscriptionId'), parameters('identitySubscriptionId')), createArray(parameters('singlePlatformSubscriptionId'))))]",
+        "subscriptionIds": "[union(parameters('onlineLzSubscriptionId'), parameters('corpLzSubscriptionId'), map(parameters('corpConnectedLzSubscriptionId'), lambda('sub', lambdaVariables('sub').subs)), if(empty(parameters('singlePlatformSubscriptionId')), createArray(parameters('managementSubscriptionId'), parameters('connectivitySubscriptionId'), parameters('identitySubscriptionId')), createArray(parameters('singlePlatformSubscriptionId'))))]",
         "roleDefinitions": {
             "networkContributor": "4d97b98b-1d4f-4787-a291-c67834d212e7"
         },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Parameter `corpConnectedLzSubscriptionId ` receives an object from the portal output. This object contains both subscription IDs and address spaces. This caused an issue in `subscriptionIds ` (array of subscriptions IDs.)

Now uses lambda function to obtain the subscription IDs from `corpConnectedLzSubscriptionId`. This fixes Invalid Template error when selecting a corp connected landing zone deployment.

## This PR fixes/adds/changes/removes

1. Fixes #1570 

### Breaking Changes

None

## Testing Evidence

Tested:
- Hub and spoke - corp not connected
- Hub and spoke - corp connected
- Hub and spoke - online
- Virtual WAN 

Deployment:
![image](https://github.com/Azure/Enterprise-Scale/assets/15944031/54f91389-a1b5-409c-b32a-44c1dcc712fe)

### Testing URLs

The below URLs can be updated where the placeholders are, look for `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}` & `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}`, to allow you to test your portal deployment experience.

> Please also replace the curly brackets on the placeholders `{}`

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2F1570-portal-deployment-issue%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2F1570-portal-deployment-issue%2FeslzArm%2Feslz-portal.json)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
