### PR TITLE
Hotfix: previously updated policy not updated in initiative (low priority)

### DIFF
--- a/src/resources/Microsoft.Authorization/policySetDefinitions/Deploy-Sql-Security.json
+++ b/src/resources/Microsoft.Authorization/policySetDefinitions/Deploy-Sql-Security.json
@@ -114,7 +114,7 @@
       },
       {
         "policyDefinitionReferenceId": "SqlDbVulnerabilityAssessmentsDeploySqlSecurity",
-        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-vulnerabilityAssessments",
+        "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/contoso/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-vulnerabilityAssessments_20230706",
         "parameters": {
           "effect": {
             "value": "[[parameters('SqlDbVulnerabilityAssessmentsDeploySqlSecurityEffect')]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes a change to the `src/resources/Microsoft.Authorization/policySetDefinitions/Deploy-Sql-Security.json` file. The `policyDefinitionId` for `SqlDbVulnerabilityAssessmentsDeploySqlSecurity` has been updated to include a date suffix `_20230706`, likely indicating a version update or specific configuration for this policy definition.

### Testing URLs

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FHF2%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FHF2%2FeslzArm%2Feslz-portal.json)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
