### PR TITLE
Add policy set definition workaround

### DIFF
--- a/src/Alz.Tools/functions/Alz.Tools.ps1
+++ b/src/Alz.Tools/functions/Alz.Tools.ps1
@@ -71,6 +71,10 @@ function ProcessObjectByResourceType {
             }
             "microsoft.authorization/policysetdefinitions" {
                 $outputObject = [PolicySetDefinition]::new($ResourceObject)
+                # Workaround for policySetDefinitions that only have a single policyDefinition. PowerShell tires to convert to an object in that scenario.
+                if($outputObject.properties.policyDefinitions.GetType().ToString() -eq "PolicySetDefinitionPropertiesPolicyDefinitions") {
+                    $outputObject.properties.policyDefinitions = @($outputObject.properties.policyDefinitions)
+                }
             }
             "microsoft.authorization/roleassignments" {
                 $outputObject = [RoleAssignment]::new($ResourceObject)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This fixes an issue where policy set definitions only reference one policy definition.

I tried various workarounds in the class definitions before resorting this option. It appears there is a fundamental issue in PowerShell that results in needing to fix it like this rather than in the class constructor / definition as you would expect.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

N/A

## Testing Evidence

This is a fix to a script library used for policy sync, so does not need portal testing.

You can see a working run based on this branch over here: https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pull/972/files

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
