### PR TITLE
Update Wiki Flow

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout Source Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ env.wiki_source_repo }}
           path: ${{ env.wiki_source_repo }}
 
       - name: Checkout Wiki Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ env.wiki_target_repo }}
           path: ${{ env.wiki_target_repo }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow in the `.github/workflows/wiki-sync.yml` file. The version of the `actions/checkout` action used in both the "Checkout Source Repo" and "Checkout Wiki Repo" steps has been upgraded from `v2` to `v4`.

* [`.github/workflows/wiki-sync.yml`](diffhunk://#diff-d10fbafe68dafbf80e3429b0c8fb2a98cb3a6bbf4dc44660aabeaacc979856d7L31-R37): Upgraded `actions/checkout` action from `v2` to `v4` in both "Checkout Source Repo" and "Checkout Wiki Repo" steps. This update may include improvements or new features that enhance the checkout process.