### PR TITLE
fix: [[, double effect, empty default

### DIFF
--- a/src/resources/Microsoft.Authorization/policySetDefinitions/Deploy-Private-DNS-Zones.json
+++ b/src/resources/Microsoft.Authorization/policySetDefinitions/Deploy-Private-DNS-Zones.json
@@ -18,7 +18,6 @@
     "parameters": {
       "azureFilePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureFilePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -27,7 +26,6 @@
       },
       "azureAutomationWebhookPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureAutomationWebhookPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -36,7 +34,6 @@
       },
       "azureAutomationDSCHybridPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureAutomationDSCHybridPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -45,7 +42,6 @@
       },
       "azureCosmosSQLPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureCosmosSQLPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -54,7 +50,6 @@
       },
       "azureCosmosMongoPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureCosmosMongoPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -63,7 +58,6 @@
       },
       "azureCosmosCassandraPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureCosmosCassandraPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -72,7 +66,6 @@
       },
       "azureCosmosGremlinPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureCosmosGremlinPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -81,7 +74,6 @@
       },
       "azureCosmosTablePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureCosmosTablePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -90,7 +82,6 @@
       },
       "azureDataFactoryPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureDataFactoryPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -99,7 +90,6 @@
       },
       "azureDataFactoryPortalPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureDataFactoryPortalPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -108,7 +98,6 @@
       },
       "azureDatabricksPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureDatabricksPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -117,7 +106,6 @@
       },
       "azureHDInsightPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureHDInsightPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -126,7 +114,6 @@
       },
       "azureMigratePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMigratePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -135,7 +122,6 @@
       },
       "azureStorageBlobPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageBlobPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -144,7 +130,6 @@
       },
       "azureStorageBlobSecPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageBlobSecPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -153,7 +138,6 @@
       },
       "azureStorageQueuePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageQueuePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -162,7 +146,6 @@
       },
       "azureStorageQueueSecPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageQueueSecPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -171,7 +154,6 @@
       },
       "azureStorageFilePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageFilePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -180,7 +162,6 @@
       },
       "azureStorageStaticWebPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageStaticWebPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -189,7 +170,6 @@
       },
       "azureStorageStaticWebSecPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageStaticWebSecPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -198,7 +178,6 @@
       },
       "azureStorageDFSPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageDFSPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -207,7 +186,6 @@
       },
       "azureStorageDFSSecPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageDFSSecPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -216,7 +194,6 @@
       },
       "azureSynapseSQLPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureSynapseSQLPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -225,7 +202,6 @@
       },
       "azureSynapseSQLODPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureSynapseSQLODPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -234,7 +210,6 @@
       },
       "azureSynapseDevPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureSynapseDevPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -243,7 +218,6 @@
       },
       "azureMediaServicesKeyPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMediaServicesKeyPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -252,7 +226,6 @@
       },
       "azureMediaServicesLivePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMediaServicesLivePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -261,7 +234,6 @@
       },
       "azureMediaServicesStreamPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMediaServicesStreamPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -270,7 +242,6 @@
       },
       "azureMonitorPrivateDnsZoneId1": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMonitorPrivateDnsZoneId1",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -279,7 +250,6 @@
       },
       "azureMonitorPrivateDnsZoneId2": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMonitorPrivateDnsZoneId2",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -288,7 +258,6 @@
       },
       "azureMonitorPrivateDnsZoneId3": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMonitorPrivateDnsZoneId3",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -297,7 +266,6 @@
       },
       "azureMonitorPrivateDnsZoneId4": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMonitorPrivateDnsZoneId4",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -306,7 +274,6 @@
       },
       "azureMonitorPrivateDnsZoneId5": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMonitorPrivateDnsZoneId5",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -315,7 +282,6 @@
       },
       "azureWebPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureWebPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -324,7 +290,6 @@
       },
       "azureBatchPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureBatchPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -333,7 +298,6 @@
       },
       "azureAppPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureAppPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -342,7 +306,6 @@
       },
       "azureAsrPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureAsrPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -351,7 +314,6 @@
       },
       "azureIotPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureIotPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -360,7 +322,6 @@
       },
       "azureKeyVaultPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureKeyVaultPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -369,7 +330,6 @@
       },
       "azureSignalRPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureSignalRPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -378,7 +338,6 @@
       },
       "azureAppServicesPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureAppServicesPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -387,7 +346,6 @@
       },
       "azureEventGridTopicsPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureEventGridTopicsPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -396,7 +354,6 @@
       },
       "azureDiskAccessPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureDiskAccessPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -405,7 +362,6 @@
       },
       "azureCognitiveServicesPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureCognitiveServicesPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -414,7 +370,6 @@
       },
       "azureIotHubsPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureIotHubsPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -423,7 +378,6 @@
       },
       "azureEventGridDomainsPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureEventGridDomainsPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -432,7 +386,6 @@
       },
       "azureRedisCachePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureRedisCachePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -441,7 +394,6 @@
       },
       "azureAcrPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureAcrPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -450,7 +402,6 @@
       },
       "azureEventHubNamespacePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureEventHubNamespacePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -459,7 +410,6 @@
       },
       "azureMachineLearningWorkspacePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMachineLearningWorkspacePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -468,7 +418,6 @@
       },
       "azureMachineLearningWorkspaceSecondPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureMachineLearningWorkspaceSecondPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -477,7 +426,6 @@
       },
       "azureServiceBusNamespacePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureServiceBusNamespacePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -486,7 +434,6 @@
       },
       "azureCognitiveSearchPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureCognitiveSearchPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -495,7 +442,6 @@
       },
       "azureBotServicePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureBotServicePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -504,7 +450,6 @@
       },
       "azureManagedGrafanaWorkspacePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureManagedGrafanaWorkspacePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -513,7 +458,6 @@
       },
       "azureVirtualDesktopHostpoolPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureVirtualDesktopHostpoolPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -522,7 +466,6 @@
       },
       "azureVirtualDesktopWorkspacePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureVirtualDesktopWorkspacePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -531,7 +474,6 @@
       },
       "azureIotDeviceupdatePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureIotDeviceupdatePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -540,7 +482,6 @@
       },
       "azureArcGuestconfigurationPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureArcGuestconfigurationPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -549,7 +490,6 @@
       },
       "azureArcHybridResourceProviderPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureArcHybridResourceProviderPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -558,7 +498,6 @@
       },
       "azureArcKubernetesConfigurationPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureArcKubernetesConfigurationPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -567,7 +506,6 @@
       },
       "azureIotCentralPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureIotCentralPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -576,7 +514,6 @@
       },
       "azureStorageTablePrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageTablePrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -585,7 +522,6 @@
       },
       "azureStorageTableSecondaryPrivateDnsZoneId": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureStorageTableSecondaryPrivateDnsZoneId",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -594,7 +530,6 @@
       },
       "azureSiteRecoveryBackupPrivateDnsZoneID": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureSiteRecoveryBackupPrivateDnsZoneID",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -603,7 +538,6 @@
       },
       "azureSiteRecoveryBlobPrivateDnsZoneID": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureSiteRecoveryBlobPrivateDnsZoneID",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -612,7 +546,6 @@
       },
       "azureSiteRecoveryQueuePrivateDnsZoneID": {
         "type": "string",
-        "defaultValue": "",
         "metadata": {
           "displayName": "azureSiteRecoveryQueuePrivateDnsZoneID",
           "strongType": "Microsoft.Network/privateDnsZones",
@@ -630,18 +563,6 @@
           "Disabled"
         ],
         "defaultValue": "DeployIfNotExists"
-      },
-      "effect1": {
-        "type": "string",
-        "metadata": {
-          "displayName": "Effect",
-          "description": "Enable or disable the execution of the policy"
-        },
-        "allowedValues": [
-          "deployIfNotExists",
-          "Disabled"
-        ],
-        "defaultValue": "deployIfNotExists"
       }
     },
     "policyDefinitions": [
@@ -650,10 +571,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/06695360-db88-47f6-b976-7500d4297475",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureFilePrivateDnsZoneId')]"
+            "value": "[parameters('azureFilePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -663,13 +584,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6dd01e4f-1be1-4e80-9d0b-d109e04cb064",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureAutomationWebhookPrivateDnsZoneId')]"
+            "value": "[parameters('azureAutomationWebhookPrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "Webhook"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -679,13 +600,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6dd01e4f-1be1-4e80-9d0b-d109e04cb064",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureAutomationDSCHybridPrivateDnsZoneId')]"
+            "value": "[parameters('azureAutomationDSCHybridPrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "DSCAndHybridWorker"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -695,13 +616,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureCosmosSQLPrivateDnsZoneId')]"
+            "value": "[parameters('azureCosmosSQLPrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "SQL"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -711,13 +632,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureCosmosMongoPrivateDnsZoneId')]"
+            "value": "[parameters('azureCosmosMongoPrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "MongoDB"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -727,13 +648,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureCosmosCassandraPrivateDnsZoneId')]"
+            "value": "[parameters('azureCosmosCassandraPrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "Cassandra"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -743,13 +664,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureCosmosGremlinPrivateDnsZoneId')]"
+            "value": "[parameters('azureCosmosGremlinPrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "Gremlin"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -759,13 +680,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a63cc0bd-cda4-4178-b705-37dc439d3e0f",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureCosmosTablePrivateDnsZoneId')]"
+            "value": "[parameters('azureCosmosTablePrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "Table"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -775,7 +696,7 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86cd96e1-1745-420d-94d4-d3f2fe415aa4",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureDataFactoryPrivateDnsZoneId')]"
+            "value": "[parameters('azureDataFactoryPrivateDnsZoneId')]"
           },
           "listOfGroupIds": {
             "value": [
@@ -783,7 +704,7 @@
             ]
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -793,7 +714,7 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86cd96e1-1745-420d-94d4-d3f2fe415aa4",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureDataFactoryPortalPrivateDnsZoneId')]"
+            "value": "[parameters('azureDataFactoryPortalPrivateDnsZoneId')]"
           },
           "listOfGroupIds": {
             "value": [
@@ -801,7 +722,7 @@
             ]
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -811,13 +732,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0eddd7f3-3d9b-4927-a07a-806e8ac9486c",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureDatabricksPrivateDnsZoneId')]"
+            "value": "[parameters('azureDatabricksPrivateDnsZoneId')]"
           },
           "groupId": {
             "value": "databricks_ui_api"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -827,13 +748,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0eddd7f3-3d9b-4927-a07a-806e8ac9486c",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureDatabricksPrivateDnsZoneId')]"
+            "value": "[parameters('azureDatabricksPrivateDnsZoneId')]"
           },
           "groupId": {
             "value": "browser_authentication"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -843,13 +764,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/43d6e3bd-fc6a-4b44-8b4d-2151d8736a11",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureHDInsightPrivateDnsZoneId')]"
+            "value": "[parameters('azureHDInsightPrivateDnsZoneId')]"
           },
           "groupId": {
             "value": "cluster"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -859,10 +780,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7590a335-57cf-4c95-babd-ecbc8fafeb1f",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureMigratePrivateDnsZoneId')]"
+            "value": "[parameters('azureMigratePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -872,10 +793,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/75973700-529f-4de2-b794-fb9b6781b6b0",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageBlobPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageBlobPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -885,10 +806,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d847d34b-9337-4e2d-99a5-767e5ac9c582",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageBlobSecPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageBlobSecPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -898,10 +819,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/bcff79fb-2b0d-47c9-97e5-3023479b00d1",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageQueuePrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageQueuePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -911,10 +832,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/da9b4ae8-5ddc-48c5-b9c0-25f8abf7a3d6",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageQueueSecPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageQueueSecPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -924,10 +845,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6df98d03-368a-4438-8730-a93c4d7693d6",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageFilePrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageFilePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -937,10 +858,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9adab2a5-05ba-4fbd-831a-5bf958d04218",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageStaticWebPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageStaticWebPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -950,10 +871,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d19ae5f1-b303-4b82-9ca8-7682749faf0c",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageStaticWebSecPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageStaticWebSecPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -963,10 +884,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/83c6fe0f-2316-444a-99a1-1ecd8a7872ca",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageDFSPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageDFSPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -976,10 +897,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/90bd4cb3-9f59-45f7-a6ca-f69db2726671",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageDFSSecPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageDFSSecPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -989,13 +910,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1e5ed725-f16c-478b-bd4b-7bfa2f7940b9",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureSynapseSQLPrivateDnsZoneId')]"
+            "value": "[parameters('azureSynapseSQLPrivateDnsZoneId')]"
           },
           "targetSubResource": {
             "value": "Sql"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1005,13 +926,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1e5ed725-f16c-478b-bd4b-7bfa2f7940b9",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureSynapseSQLODPrivateDnsZoneId')]"
+            "value": "[parameters('azureSynapseSQLODPrivateDnsZoneId')]"
           },
           "targetSubResource": {
             "value": "SqlOnDemand"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1021,13 +942,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1e5ed725-f16c-478b-bd4b-7bfa2f7940b9",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureSynapseDevPrivateDnsZoneId')]"
+            "value": "[parameters('azureSynapseDevPrivateDnsZoneId')]"
           },
           "targetSubResource": {
             "value": "Dev"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1037,13 +958,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b4a7f6c1-585e-4177-ad5b-c2c93f4bb991",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureMediaServicesKeyPrivateDnsZoneId')]"
+            "value": "[parameters('azureMediaServicesKeyPrivateDnsZoneId')]"
           },
           "groupId": {
             "value": "keydelivery"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1053,13 +974,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b4a7f6c1-585e-4177-ad5b-c2c93f4bb991",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureMediaServicesLivePrivateDnsZoneId')]"
+            "value": "[parameters('azureMediaServicesLivePrivateDnsZoneId')]"
           },
           "groupId": {
             "value": "liveevent"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1069,13 +990,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b4a7f6c1-585e-4177-ad5b-c2c93f4bb991",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureMediaServicesStreamPrivateDnsZoneId')]"
+            "value": "[parameters('azureMediaServicesStreamPrivateDnsZoneId')]"
           },
           "groupId": {
             "value": "streamingendpoint"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1085,22 +1006,22 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/437914ee-c176-4fff-8986-7e05eb971365",
         "parameters": {
           "privateDnsZoneId1": {
-            "value": "[[parameters('azureMonitorPrivateDnsZoneId1')]"
+            "value": "[parameters('azureMonitorPrivateDnsZoneId1')]"
           },
           "privateDnsZoneId2": {
-            "value": "[[parameters('azureMonitorPrivateDnsZoneId2')]"
+            "value": "[parameters('azureMonitorPrivateDnsZoneId2')]"
           },
           "privateDnsZoneId3": {
-            "value": "[[parameters('azureMonitorPrivateDnsZoneId3')]"
+            "value": "[parameters('azureMonitorPrivateDnsZoneId3')]"
           },
           "privateDnsZoneId4": {
-            "value": "[[parameters('azureMonitorPrivateDnsZoneId4')]"
+            "value": "[parameters('azureMonitorPrivateDnsZoneId4')]"
           },
           "privateDnsZoneId5": {
-            "value": "[[parameters('azureMonitorPrivateDnsZoneId5')]"
+            "value": "[parameters('azureMonitorPrivateDnsZoneId5')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1110,10 +1031,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/0b026355-49cb-467b-8ac4-f777874e175a",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureWebPrivateDnsZoneId')]"
+            "value": "[parameters('azureWebPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1123,10 +1044,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/4ec38ebc-381f-45ee-81a4-acbc4be878f8",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureBatchPrivateDnsZoneId')]"
+            "value": "[parameters('azureBatchPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1136,10 +1057,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/7a860e27-9ca2-4fc6-822d-c2d248c300df",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureAppPrivateDnsZoneId')]"
+            "value": "[parameters('azureAppPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1149,10 +1070,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/942bd215-1a66-44be-af65-6a1c0318dbe2",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureAsrPrivateDnsZoneId')]"
+            "value": "[parameters('azureAsrPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1162,10 +1083,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/aaa64d2d-2fa3-45e5-b332-0b031b9b30e8",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureIotPrivateDnsZoneId')]"
+            "value": "[parameters('azureIotPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1175,10 +1096,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ac673a9a-f77d-4846-b2d8-a57f8e1c01d4",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureKeyVaultPrivateDnsZoneId')]"
+            "value": "[parameters('azureKeyVaultPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1188,10 +1109,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b0e86710-7fb7-4a6c-a064-32e9b829509e",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureSignalRPrivateDnsZoneId')]"
+            "value": "[parameters('azureSignalRPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1201,10 +1122,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/b318f84a-b872-429b-ac6d-a01b96814452",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureAppServicesPrivateDnsZoneId')]"
+            "value": "[parameters('azureAppServicesPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1214,10 +1135,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/baf19753-7502-405f-8745-370519b20483",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureEventGridTopicsPrivateDnsZoneId')]"
+            "value": "[parameters('azureEventGridTopicsPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect1')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1227,10 +1148,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/bc05b96c-0b36-4ca9-82f0-5c53f96ce05a",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureDiskAccessPrivateDnsZoneId')]"
+            "value": "[parameters('azureDiskAccessPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1240,10 +1161,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/c4bc6f10-cb41-49eb-b000-d5ab82e2a091",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureCognitiveServicesPrivateDnsZoneId')]"
+            "value": "[parameters('azureCognitiveServicesPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1253,10 +1174,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/c99ce9c1-ced7-4c3e-aca0-10e69ce0cb02",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureIotHubsPrivateDnsZoneId')]"
+            "value": "[parameters('azureIotHubsPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect1')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1266,10 +1187,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d389df0a-e0d7-4607-833c-75a6fdac2c2d",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureEventGridDomainsPrivateDnsZoneId')]"
+            "value": "[parameters('azureEventGridDomainsPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect1')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1279,10 +1200,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e016b22b-e0eb-436d-8fd7-160c4eaed6e2",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureRedisCachePrivateDnsZoneId')]"
+            "value": "[parameters('azureRedisCachePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1292,10 +1213,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e9585a95-5b8c-4d03-b193-dc7eb5ac4c32",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureAcrPrivateDnsZoneId')]"
+            "value": "[parameters('azureAcrPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1305,10 +1226,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ed66d4f5-8220-45dc-ab4a-20d1749c74e6",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureEventHubNamespacePrivateDnsZoneId')]"
+            "value": "[parameters('azureEventHubNamespacePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1318,13 +1239,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/ee40564d-486e-4f68-a5ca-7a621edae0fb",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureMachineLearningWorkspacePrivateDnsZoneId')]"
+            "value": "[parameters('azureMachineLearningWorkspacePrivateDnsZoneId')]"
           },
           "secondPrivateDnsZoneId": {
-            "value": "[[parameters('azureMachineLearningWorkspaceSecondPrivateDnsZoneId')]"
+            "value": "[parameters('azureMachineLearningWorkspaceSecondPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1334,10 +1255,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/f0fcf93c-c063-4071-9668-c47474bd3564",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureServiceBusNamespacePrivateDnsZoneId')]"
+            "value": "[parameters('azureServiceBusNamespacePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1347,10 +1268,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/fbc14a67-53e4-4932-abcc-2049c6706009",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureCognitiveSearchPrivateDnsZoneId')]"
+            "value": "[parameters('azureCognitiveSearchPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         },
         "groupNames": []
@@ -1360,10 +1281,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6a4e6f44-f2af-4082-9702-033c9e88b9f8",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureBotServicePrivateDnsZoneId')]"
+            "value": "[parameters('azureBotServicePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1372,10 +1293,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/4c8537f8-cd1b-49ec-b704-18e82a42fd58",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureManagedGrafanaWorkspacePrivateDnsZoneId')]"
+            "value": "[parameters('azureManagedGrafanaWorkspacePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1384,13 +1305,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9427df23-0f42-4e1e-bf99-a6133d841c4a",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureVirtualDesktopHostpoolPrivateDnsZoneId')]"
+            "value": "[parameters('azureVirtualDesktopHostpoolPrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "connection"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1399,13 +1320,13 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/34804460-d88b-4922-a7ca-537165e060ed",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureVirtualDesktopWorkspacePrivateDnsZoneId')]"
+            "value": "[parameters('azureVirtualDesktopWorkspacePrivateDnsZoneId')]"
           },
           "privateEndpointGroupId": {
             "value": "feed"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1414,10 +1335,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a222b93a-e6c2-4c01-817f-21e092455b2a",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[[parameters('azureIotDeviceupdatePrivateDnsZoneId')]"
+            "value": "[parameters('azureIotDeviceupdatePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1426,16 +1347,16 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/55c4db33-97b0-437b-8469-c4f4498f5df9",
         "parameters":{
           "privateDnsZoneIDForGuestConfiguration": {
-            "value": "[[parameters('azureArcGuestconfigurationPrivateDnsZoneId')]"
+            "value": "[parameters('azureArcGuestconfigurationPrivateDnsZoneId')]"
           },
           "privateDnsZoneIDForHybridResourceProvider": {
-            "value": "[[parameters('azureArcHybridResourceProviderPrivateDnsZoneId')]"
+            "value": "[parameters('azureArcHybridResourceProviderPrivateDnsZoneId')]"
           },
           "privateDnsZoneIDForKubernetesConfiguration": {
-            "value": "[[parameters('azureArcKubernetesConfigurationPrivateDnsZoneId')]"
+            "value": "[parameters('azureArcKubernetesConfigurationPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1444,10 +1365,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/d627d7c6-ded5-481a-8f2e-7e16b1e6faf6",
         "parameters":{
           "privateDnsZoneId": {
-            "value": "[[parameters('azureIotCentralPrivateDnsZoneId')]"
+            "value": "[parameters('azureIotCentralPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1456,10 +1377,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/028bbd88-e9b5-461f-9424-a1b63a7bee1a",
         "parameters":{
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageTablePrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageTablePrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1468,10 +1389,10 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/c1d634a5-f73d-4cdd-889f-2cc7006eb47f",
         "parameters":{
           "privateDnsZoneId": {
-            "value": "[[parameters('azureStorageTableSecondaryPrivateDnsZoneId')]"
+            "value": "[parameters('azureStorageTableSecondaryPrivateDnsZoneId')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       },
@@ -1480,16 +1401,16 @@
         "policyDefinitionId":"/providers/Microsoft.Authorization/policyDefinitions/af783da1-4ad1-42be-800d-d19c70038820",
         "parameters":{
           "privateDnsZone-Backup": {
-            "value": "[[parameters('azureSiteRecoveryBackupPrivateDnsZoneID')]"
+            "value": "[parameters('azureSiteRecoveryBackupPrivateDnsZoneID')]"
           },
           "privateDnsZone-Blob": {
-            "value": "[[parameters('azureSiteRecoveryBlobPrivateDnsZoneID')]"
+            "value": "[parameters('azureSiteRecoveryBlobPrivateDnsZoneID')]"
           },
           "privateDnsZone-Queue": {
-            "value": "[[parameters('azureSiteRecoveryQueuePrivateDnsZoneID')]"
+            "value": "[parameters('azureSiteRecoveryQueuePrivateDnsZoneID')]"
           },
           "effect": {
-            "value": "[[parameters('effect')]"
+            "value": "[parameters('effect')]"
           }
         }
       }


### PR DESCRIPTION
Fixed double square brackets "[[parameters".
Fixed double "effect, effect1", removed "effect1". Fixed "defaultValue": "" and removed it, since all parameters are really required.

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The updated template can be deployed via the REST API without an error. Also, it will show the parameters correctly in the Azure portal.

## This PR fixes/adds/changes/removes

1. Fixes syntax error with "[["
2. Removed "effect1" since it is defined twice as "effect" and "effect1"
3. Removed defaultValue:"" since it leads to a faulty deployment, if one ignores to set all parameters, when assigning the initiative

### Breaking Changes

1. No assignment of initiative with default values possible. It would be a broken assignment anyhow.

## Testing Evidence

When deployed with "[[parameters" syntax error, the REST API throws this error:
url:
https://learn.microsoft.com/en-us/rest/api/policy/policy-set-definitions/create-or-update?view=rest-policy-2023-04-01&tabs=HTTP&tryIt=true&source=docs#code-try-0
body:
{
  "error": {
    "code": "UnusedPolicyParameters",
    "message": "The policy set '<null>' has defined parameters 'azureFilePrivateDnsZoneId,azureAutomationWebhookPrivateDnsZoneId,azureAutomationDSCHybridPrivateDnsZoneId,azureCosmosSQLPrivateDnsZoneId,azureCosmosMongoPrivateDnsZoneId,azureIotCentralPrivateDnsZoneId,azureStorageTablePrivateDnsZoneId,azureStorageTableSecondaryPrivateDnsZoneId,azureSiteRecoveryBackupPrivateDnsZoneID,azureSiteRecoveryBlobPrivateDnsZoneID,azureSiteRecoveryQueuePrivateDnsZoneID' which are not used in referenced policy definitions. Please either remove these parameters from the definition or ensure that they are used."
  }
}

When deployed with "effect" and "effect1", it will show double in the Azure portal:
![image](https://github.com/Azure/Enterprise-Scale/assets/16253984/dd647e08-d07e-4808-983e-d649554223f4)

When deployed with "defaultValue": "", it will not show the parameters in the Azure portal, even though they are really required:
![image](https://github.com/Azure/Enterprise-Scale/assets/16253984/9634110b-72a8-42bc-89ba-af141413bd6b)

The fixed version can be deployed trough the REST API, plus it will show the parameters correctly and the effect shows up only once:
![image](https://github.com/Azure/Enterprise-Scale/assets/16253984/cf20ae8d-40a1-41f3-8950-16194c30be10)

![image](https://github.com/Azure/Enterprise-Scale/assets/16253984/9d19d2fb-7bab-4832-880f-55d291c35193)

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2F{YOUR GITHUB ORG/ACCOUNT HERE - Remove Curly Brackets Also}%2FEnterprise-Scale%2F{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2F{YOUR GITHUB ORG/ACCOUNT HERE - Remove Curly Brackets Also}%2FEnterprise-Scale%2F{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}%2FeslzArm%2Feslz-portal.json)

#### Azure US Gov (Fairfax)
[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2F{YOUR GITHUB ORG/ACCOUNT HERE - Remove Curly Brackets Also}%2FEnterprise-Scale%2F{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2F{YOUR GITHUB ORG/ACCOUNT HERE - Remove Curly Brackets Also}%2FEnterprise-Scale%2F{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}%2FeslzArm%2Ffairfaxeslz-portal.json)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
