### PR TITLE
Updating GH Workflow to validate policy file and meta names are the same

### DIFF
--- a/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
+++ b/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
@@ -109,6 +109,16 @@ Describe 'UnitTest-ModifiedPolicies' {
             }
         }
 
+        It "Check policy metadata name matches policy filename" {
+            $ModifiedAddedFiles | ForEach-Object {
+                $PolicyJson = Get-Content -Path $_ -Raw | ConvertFrom-Json
+                $PolicyFile = Split-Path $_ -Leaf
+                $PolicyMetadataName = $PolicyJson.properties.metadata.name
+                Write-Warning "$($PolicyFile) - This is the policy metadata name: $($PolicyMetadataName)"
+                $PolicyMetadataName | Should -Be substr($PolicyFile, 0, $PolicyFile.Length - 5)
+            }
+        }
+
         }
         
         Context "Validate policy parameters" {

--- a/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
+++ b/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
@@ -113,9 +113,14 @@ Describe 'UnitTest-ModifiedPolicies' {
             $ModifiedAddedFiles | ForEach-Object {
                 $PolicyJson = Get-Content -Path $_ -Raw | ConvertFrom-Json
                 $PolicyFile = Split-Path $_ -Leaf
-                $PolicyMetadataName = $PolicyJson.properties.metadata.name
-                Write-Warning "$($PolicyFile) - This is the policy metadata name: $($PolicyMetadataName)"
-                $PolicyMetadataName | Should -Be substr($PolicyFile, 0, $PolicyFile.Length - 5)
+                $PolicyMetadataName = $PolicyJson.name
+                $PolicyFileNoExt = [System.IO.Path]::GetFileNameWithoutExtension($PolicyFile)
+                if ($PolicyFileNoExt.Contains("AzureChinaCloud") -or $PolicyFileNoExt.Contains("AzureUSGovernment"))
+                {
+                    $PolicyFileNoExt = $PolicyFileNoExt.Substring(0, $PolicyFileNoExt.IndexOf("."))
+                }
+                Write-Warning "$($PolicyFileNoExt) - This is the policy metadata name: $($PolicyMetadataName)"
+                $PolicyMetadataName | Should -Be $PolicyFileNoExt
             }
         }
 

--- a/src/resources/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly.json
@@ -9,7 +9,7 @@
     "displayName": "AppService append enable https only setting to enforce https setting.",
     "description": "Appends the AppService sites object to ensure that  HTTPS only is enabled for  server/service authentication and protects data in transit from network layer eavesdropping attacks. Please note Append does not enforce compliance use then deny.",
     "metadata": {
-      "version": "1.0.1",
+      "version": "1.0.0",
       "category": "App Service",
       "source": "https://github.com/Azure/Enterprise-Scale/",
       "alzCloudEnvironments": [

--- a/src/resources/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly.json
@@ -9,7 +9,7 @@
     "displayName": "AppService append enable https only setting to enforce https setting.",
     "description": "Appends the AppService sites object to ensure that  HTTPS only is enabled for  server/service authentication and protects data in transit from network layer eavesdropping attacks. Please note Append does not enforce compliance use then deny.",
     "metadata": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "App Service",
       "source": "https://github.com/Azure/Enterprise-Scale/",
       "alzCloudEnvironments": [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request introduces a new unit test in the `UnitTest-ModifiedPolicies` describe block in the `.github/actions-pester/Test-ModifiedPolicies.Tests.ps1` file. The new test ensures that the policy metadata name matches the policy filename.

* [`.github/actions-pester/Test-ModifiedPolicies.Tests.ps1`](diffhunk://#diff-34ade58f9aa37ceb0f0ad447cd0bf82c535dd1c0aedfa1921fe3eac8f4d0c764R112-R126): Added a new test case "Check policy metadata name matches policy filename" in the `UnitTest-ModifiedPolicies` describe block. This test checks each modified and added file, extracts the policy metadata name from the JSON content, and compares it with the filename without extension. If the filename contains "AzureChinaCloud" or "AzureUSGovernment", the comparison is made with the substring before the first period. The test asserts that the policy metadata name should be the same as the filename without extension.

Addresses [AB#31354](https://dev.azure.com/CSUSolEng/2a9d5a5a-8998-4ad0-81c8-ef3045e4da97/_workitems/edit/31354)
