### PR TITLE
Update test to remove deprecated parameter

### DIFF
--- a/eslzArm/eslzArm.test.param.json
+++ b/eslzArm/eslzArm.test.param.json
@@ -245,9 +245,6 @@
         "enableVmssMonitoring": {
             "value": "Yes"
         },
-        "enableAksPolicy": {
-            "value": "Yes"
-        },
         "denyAksPrivileged": {
             "value": "Yes"
         },


### PR DESCRIPTION
This pull request includes a change to the `eslzArm/eslzArm.test.param.json` file to remove the `enableAksPolicy` parameter, which is no longer needed.

* [`eslzArm/eslzArm.test.param.json`](diffhunk://#diff-bfccc174e492b9ae29dc293e9a1b727933de33014038a3734359449b540ee7d6L248-L250): Removed the `enableAksPolicy` parameter.