### PR TITLE
Refactor policy test to exclude certain policies and parameters

### DIFF
--- a/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
+++ b/.github/actions-pester/Test-ModifiedPolicies.Tests.ps1
@@ -131,17 +131,26 @@ Describe 'UnitTest-ModifiedPolicies' {
                 $ModifiedAddedFiles | ForEach-Object {
                     $PolicyJson = Get-Content -Path $_ -Raw | ConvertFrom-Json
                     $PolicyFile = Split-Path $_ -Leaf
-                    $PolicyParameters = $PolicyJson.properties.parameters
-                    if ($PolicyParameters | Get-Member -MemberType NoteProperty)
+                    $PolicyMetadataName = $PolicyJson.name
+                    $ExcludePolicy = @("Deploy-Private-DNS-Zones","Deploy-Vm-autoShutdown","Deploy-Custom-Route-Table","Deploy-DDoSProtection","Deploy-Default-Udr")
+                    $ExcludeParams = @("allowedVnets","userAssignedIdentityName","identityResourceGroup","resourceName","logAnalytics","ddosPlanResourceId","modifyUdrNextHopIpAddress","emailSecurityContact","contactEmails","contactGroups","contactRoles","privateDnsZoneId","resourceType","groupId","azureAcrPrivateDnsZoneId","userWorkspaceResourceId","workspaceRegion","dcrName","dcrResourceGroup","dcrId","keyVaultNonIntegratedCaValue","excludedSubnets","excludedDestinations","allowedBypassOptions","ports","denyMgmtFromInternetPorts","allowedVmSizes","allowedKinds","predefinedPolicyName","privateLinkDnsZones","locations","tagValues","ascExportResourceGroupLocation","ascExportResourceGroupName","vulnerabilityAssessmentsEmail","vulnerabilityAssessmentsStorageID","listOfResourceTypesAllowed","listOfResourceTypesNotAllowed","synapseAllowedTenantIds","storageAllowedNetworkAclsBypass","keyVaultIntegratedCaValue","keyVaultHmsCurveNamesValue")
+                    if ($PolicyMetadataName -notin $ExcludePolicy)
                     {
-                        $Parameters = $PolicyParameters | Get-Member -MemberType NoteProperty | Select-Object -Expand Name
-                        Write-Warning "$($PolicyFile) - These are the params: $($Parameters)"
-                        $Parameters = $PolicyParameters | Get-Member -MemberType NoteProperty
-                        $Parameters | ForEach-Object {
-                            $key = $_.name
-                            $defaultValue = $PolicyParameters.$key | Get-Member -MemberType NoteProperty | Where-Object Name -EQ "defaultValue"
-                            Write-Warning "$($PolicyFile) - Parameter: $($key) - Default Value: $($defaultValue)"
-                            $PolicyParameters.$key.defaultValue | Should -Not -BeNullOrEmpty
+                        $PolicyParameters = $PolicyJson.properties.parameters
+                        if ($PolicyParameters | Get-Member -MemberType NoteProperty)
+                        {
+                            $Parameters = $PolicyParameters | Get-Member -MemberType NoteProperty | Select-Object -Expand Name
+                            Write-Warning "$($PolicyFile) - These are the params: $($Parameters)"
+                            $Parameters = $PolicyParameters | Get-Member -MemberType NoteProperty
+                            $Parameters | ForEach-Object {
+                                $key = $_.name
+                                if ($key -notin $ExcludeParams)
+                                {
+                                    $defaultValue = $PolicyParameters.$key | Get-Member -MemberType NoteProperty | Where-Object Name -EQ "defaultValue"
+                                    Write-Warning "$($PolicyFile) - Parameter: $($key) - Default Value: $($defaultValue)"
+                                    $PolicyParameters.$key.defaultValue | Should -Not -BeNullOrEmpty
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes updates to the unit tests for modified policies in the `Test-ModifiedPolicies.Tests.ps1` file. The changes primarily focus on excluding certain policies and parameters from the tests to streamline the testing process.

Key changes include:

### Exclusions in Policy and Parameters:

* Added a list of policies to exclude from the tests using the `$ExcludePolicy` array. (`.github/actions-pester/Test-ModifiedPolicies.Tests.ps1` [.github/actions-pester/Test-ModifiedPolicies.Tests.ps1R134-R138](diffhunk://#diff-34ade58f9aa37ceb0f0ad447cd0bf82c535dd1c0aedfa1921fe3eac8f4d0c764R134-R138))
* Added a list of parameters to exclude from the tests using the `$ExcludeParams` array. (`.github/actions-pester/Test-ModifiedPolicies.Tests.ps1` [.github/actions-pester/Test-ModifiedPolicies.Tests.ps1R134-R138](diffhunk://#diff-34ade58f9aa37ceb0f0ad447cd0bf82c535dd1c0aedfa1921fe3eac8f4d0c764R134-R138))
* Implemented conditional checks to skip excluded policies and parameters during the test execution. (`.github/actions-pester/Test-ModifiedPolicies.Tests.ps1` [[1]](diffhunk://#diff-34ade58f9aa37ceb0f0ad447cd0bf82c535dd1c0aedfa1921fe3eac8f4d0c764R147-R148) [[2]](diffhunk://#diff-34ade58f9aa37ceb0f0ad447cd0bf82c535dd1c0aedfa1921fe3eac8f4d0c764R158-R159)