### PR TITLE
Fix: Updated Deny-MgmtPorts-From-Internet.json to recognize 0.0.0.0/0 as being equivalent to * to represent all remote IP addresses

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -61,6 +61,8 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 - [Guidance](https://azure.github.io/azure-monitor-baseline-alerts/patterns/alz/UpdateToNewReleases/Update_from_release_2024-06-05/) for updating and implementing these changes in existing environments is available on the AMBA website.
 - Updated the Azure Monitoring Baseline Alerts (AMBA) integration section in the portal accelerator to include new features exposed by the AMBA solution. To read more on the changes https://azure.github.io/azure-monitor-baseline-alerts/patterns/alz/Whats-New/
 
+#### Policy
+- Updated Deny-MgmtPorts-From-Internet.json to recognize 0.0.0.0/0 as being equivalent to * to represent all remote IP addresses.
 
 ### August 2024
 

--- a/src/resources/Microsoft.Authorization/policyDefinitions/Deny-MgmtPorts-From-Internet.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/Deny-MgmtPorts-From-Internet.json
@@ -126,6 +126,10 @@
                                                 "equals": "Internet"
                                             },
                                             {
+                                                "field": "Microsoft.Network/networkSecurityGroups/securityRules/sourceAddressPrefix",
+                                                "equals": "0.0.0.0/0"
+                                            },
+                                            {
                                                 "not": {
                                                     "field": "Microsoft.Network/networkSecurityGroups/securityRules/sourceAddressPrefixes[*]",
                                                     "notEquals": "*"
@@ -135,6 +139,12 @@
                                                 "not": {
                                                     "field": "Microsoft.Network/networkSecurityGroups/securityRules/sourceAddressPrefixes[*]",
                                                     "notEquals": "Internet"
+                                                }
+                                            },
+                                            {
+                                                "not": {
+                                                    "field": "Microsoft.Network/networkSecurityGroups/securityRules/sourceAddressPrefixes[*]",
+                                                    "notEquals": "0.0.0.0/0"
                                                 }
                                             }
                                         ]
@@ -225,6 +235,10 @@
                                                         "equals": "Internet"
                                                     },
                                                     {
+                                                        "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix",
+                                                        "equals": "0.0.0.0/0"
+                                                    },
+                                                    {
                                                         "not": {
                                                             "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes[*]",
                                                             "notEquals": "*"
@@ -234,6 +248,12 @@
                                                         "not": {
                                                             "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes[*]",
                                                             "notEquals": "Internet"
+                                                        }
+                                                    },
+                                                    {
+                                                        "not": {
+                                                            "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefixes[*]",
+                                                            "notEquals": "0.0.0.0/0"
                                                         }
                                                     }
                                                 ]

--- a/src/resources/Microsoft.Authorization/policyDefinitions/Deny-MgmtPorts-From-Internet.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/Deny-MgmtPorts-From-Internet.json
@@ -9,7 +9,7 @@
         "displayName": "Management port access from the Internet should be blocked",
         "description": "This policy denies any network security rule that allows management port access from the Internet, by default blocking SSH/RDP ports.",
         "metadata": {
-            "version": "2.1.1",
+            "version": "3.0.0",
             "category": "Network",
             "source": "https://github.com/Azure/Enterprise-Scale/",
             "replacesPolicy": "Deny-RDP-From-Internet",

--- a/tests/policy/Deny-MgmtPorts-From-Internet.Tests.ps1
+++ b/tests/policy/Deny-MgmtPorts-From-Internet.Tests.ps1
@@ -36,7 +36,33 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
 
     # Create or update NSG is actually the same PUT request, hence testing create covers update as well.
     Context "Test open ports NSG is created or updated" -Tag "deny-mgmtports-from-internet-nsg-port" {
-        
+        It "Should deny non-compliant port '3389' with 0.0.0.0/0 as the source ip" -Tag "deny-noncompliant-nsg-port" {
+            AzTest -ResourceGroup {
+                param($ResourceGroup)
+
+                $networkSecurityGroup = New-AzNetworkSecurityGroup `
+                -Name "nsg-test" `
+                -ResourceGroupName $$res.ResourceGroupName `
+                -Location $ResourceGroup.Location
+
+                # Should be disallowed by policy, so exception should be thrown.
+                {
+                    $networkSecurityGroup | Add-AzNetworkSecurityRuleConfig `
+                        -Name RDP-rule `
+                        -Description "Allow RDP" `
+                        -Access Allow `
+                        -Protocol Tcp `
+                        -Direction Inbound `
+                        -Priority 200 `
+                        -SourceAddressPrefix '0.0.0.0/0' ` # Incompliant.
+                        -SourcePortRange  `
+                        -DestinationAddressPrefix  `
+                        -DestinationPortRange 3389 # Incompliant.
+                    | Set-AzNetworkSecurityGroup
+                } | Should -Throw "disallowed by policy"
+            }
+        }
+
         It "Should deny non-compliant port '3389'" -Tag "deny-noncompliant-nsg-port" {
             AzTest -ResourceGroup {
                 param($ResourceGroup)
@@ -55,12 +81,12 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         -Protocol Tcp `
                         -Direction Inbound `
                         -Priority 200 `
-                        -SourceAddressPrefix * `
-                        -SourcePortRange * `
-                        -DestinationAddressPrefix * `
+                        -SourceAddressPrefix  `
+                        -SourcePortRange  `
+                        -DestinationAddressPrefix  `
                         -DestinationPortRange 3389 # Incompliant.
                     | Set-AzNetworkSecurityGroup
-                } | Should -Throw "*disallowed by policy*"
+                } | Should -Throw "disallowed by policy"
             }
         }
 
@@ -80,12 +106,12 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         -Protocol Tcp `
                         -Direction Inbound `
                         -Priority 200 `
-                        -SourceAddressPrefix * `
-                        -SourcePortRange * `
-                        -DestinationAddressPrefix * `
+                        -SourceAddressPrefix  `
+                        -SourcePortRange  `
+                        -DestinationAddressPrefix  `
                         -DestinationPortRange 3389 # Incompliant.
                     | Set-AzNetworkSecurityGroup
-                } | Should -Throw "*disallowed by policy*"
+                } | Should -Throw "disallowed by policy"
             }
         }
 
@@ -107,12 +133,12 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         -Protocol Tcp `
                         -Direction Inbound `
                         -Priority 200 `
-                        -SourceAddressPrefix * `
-                        -SourcePortRange * `
-                        -DestinationAddressPrefix * `
+                        -SourceAddressPrefix  `
+                        -SourcePortRange  `
+                        -DestinationAddressPrefix  `
                         -DestinationPortRange "21-23" # Incompliant.
                     | Set-AzNetworkSecurityGroup
-                } | Should -Throw "*disallowed by policy*"
+                } | Should -Throw "disallowed by policy"
             }
         }
 
@@ -134,9 +160,9 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         -Protocol Tcp `
                         -Direction Inbound `
                         -Priority 200 `
-                        -SourceAddressPrefix * `
-                        -SourcePortRange * `
-                        -DestinationAddressPrefix * `
+                        -SourceAddressPrefix  `
+                        -SourcePortRange  `
+                        -DestinationAddressPrefix  `
                         -DestinationPortRange 443 # Compliant.
                     | Set-AzNetworkSecurityGroup
                 } | Should -Not -Throw
@@ -161,9 +187,9 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         -Protocol Tcp `
                         -Direction Inbound `
                         -Priority 300 `
-                        -SourceAddressPrefix * `
-                        -SourcePortRange * `
-                        -DestinationAddressPrefix * `
+                        -SourceAddressPrefix  `
+                        -SourcePortRange  `
+                        -DestinationAddressPrefix  `
                         -DestinationPortRange 443 
                     | Add-AzNetworkSecurityRuleConfig `
                         -Name SSH-rule `
@@ -172,16 +198,16 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         -Protocol Tcp `
                         -Direction Inbound `
                         -Priority 310 `
-                        -SourceAddressPrefix * `
-                        -SourcePortRange * `
-                        -DestinationAddressPrefix * `
+                        -SourceAddressPrefix  `
+                        -SourcePortRange  `
+                        -DestinationAddressPrefix  `
                         -DestinationPortRange "21-23" # Incompliant.
                     | Set-AzNetworkSecurityGroup
-                } | Should -Throw "*disallowed by policy*"
+                } | Should -Throw "disallowed by policy"
             }
         }
 
-        It "Should deny non-compliant port ranges* - API" -Tag "deny-noncompliant-nsg-port" {
+        It "Should deny non-compliant port ranges - API" -Tag "deny-noncompliant-nsg-port" {
             AzTest -ResourceGroup {
                 param($ResourceGroup)
 
@@ -194,10 +220,10 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         properties = @{
                             description = "Allow Web"
                             protocol = "Tcp"
-                            sourcePortRange = "*"
+                            sourcePortRange = ""
                             destinationPortRange = "443"
-                            sourceAddressPrefix = "*"
-                            destinationAddressPrefix = "*"
+                            sourceAddressPrefix = ""
+                            destinationAddressPrefix = ""
                             access = "Allow"
                             priority = 300
                             direction = "Inbound"
@@ -208,10 +234,10 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         properties = @{
                             description = "Allow Mgmt"
                             protocol = "Tcp"
-                            sourcePortRange = "*"
+                            sourcePortRange = ""
                             destinationPortRanges = $portRanges
-                            sourceAddressPrefix = "*"
-                            destinationAddressPrefix = "*"
+                            sourceAddressPrefix = ""
+                            destinationAddressPrefix = ""
                             access = "Allow"
                             priority = 310
                             direction = "Inbound"
@@ -246,11 +272,11 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                 else {
                     throw "Operation failed with message: '$($httpResponse.Content)'"
                 }              
-                } | Should -Throw "*disallowed by policy*"
+                } | Should -Throw "disallowed by policy"
             }
         }
 
-        It "Should allow compliant port ranges* - API" -Tag "allow-compliant-nsg-port" {
+        It "Should allow compliant port ranges - API" -Tag "allow-compliant-nsg-port" {
             AzTest -ResourceGroup {
                 param($ResourceGroup)
 
@@ -264,10 +290,10 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         properties = @{
                             description = "Allow Web2"
                             protocol = "Tcp"
-                            sourcePortRange = "*"
+                            sourcePortRange = ""
                             destinationPortRange = "443"
-                            sourceAddressPrefix = "*"
-                            destinationAddressPrefix = "*"
+                            sourceAddressPrefix = ""
+                            destinationAddressPrefix = ""
                             access = "Allow"
                             priority = 300
                             direction = "Inbound"
@@ -278,10 +304,10 @@ Describe "Testing policy 'Deny-MgmtPorts-From-Internet'" -Tag "deny-mgmtports-fr
                         properties = @{
                             description = "Allow Mgmt3"
                             protocol = "Tcp"
-                            sourcePortRange = "*"
+                            sourcePortRange = ""
                             destinationPortRanges = $portRanges
-                            sourceAddressPrefix = "*"
-                            destinationAddressPrefix = "*"
+                            sourceAddressPrefix = ""
+                            destinationAddressPrefix = ""
                             access = "Allow"
                             priority = 310
                             direction = "Inbound"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. The policy checks for the source address to be * or Internet, but doesn't check for 0.0.0.0/0. Per https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview
"0.0.0.0/0 in the Source and Destination columns represents all addresses"

### Breaking Changes

1. Any deployed NSG's which were previously bypassing this policy by using 0.0.0.0/0 will be denied as non-compliant.

## Testing Evidence
<img width="567" alt="nsg1" src="https://github.com/user-attachments/assets/6ffc3633-896a-4fd5-8260-b81f520e2933">
<img width="443" alt="nsg2" src="https://github.com/user-attachments/assets/3c825a60-6e1a-4472-9b92-9564231a0d17">


### Testing URLs

The below URLs can be updated where the placeholders are, look for `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}` & `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}`, to allow you to test your portal deployment experience.

> Please also replace the curly brackets on the placeholders `{}`

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frybal06%2FEnterprise-Scale%2Ffix--add-0.0.0.0/0-to-deny-mgmtports-from-internet%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Frybal06%2FEnterprise-Scale%2Ffix--add-0.0.0.0/0-to-deny-mgmtports-from-internet%2FeslzArm%2Feslz-portal.json)

#### Azure US Gov (Fairfax)
[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frybal06%2FEnterprise-Scale%2Ffix--add-0.0.0.0/0-to-deny-mgmtports-from-internet%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Frybal06%2FEnterprise-Scale%2Ffix--add-0.0.0.0/0-to-deny-mgmtports-from-internet%2FeslzArm%2Ffairfaxeslz-portal.json)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [X] Performed testing and provided evidence.
- [X] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [NA] Updated relevant and associated documentation.
- [X] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
