### PR TITLE
Add release.json with Azure Enterprise-Scale template details

### DIFF
--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,0 +1,5 @@
+{
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2024-10-14",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-10-14/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-10-14/eslzArm/eslz-portal.json"
+}

--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,5 +1,5 @@
 {
-    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2024-10-14",
-    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-10-14/eslzArm/eslzArm.json",
-    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-10-14/eslzArm/eslz-portal.json"
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2024-10-17",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-10-17/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-10-17/eslzArm/eslz-portal.json"
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes a small change to the `src/portal/release.json` file. The change updates the URIs for the Azure landing zone template, template, and UI form definition to their new locations.

* [`src/portal/release.json`](diffhunk://#diff-d1b83f222e066ed2dbdd52d52eb7ff2d5540200033f1034b74eda5e8564a56eeR1-R5): Updated `azureLandingZoneTemplateDetailsUri`, `templateUri`, and `uiFormDefinitionUri` to point to the new 2024-10-14 version.
