### PR TITLE
Policy Assignment Delay increase

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -74,6 +74,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 #### Tooling
 
 - Resolved a bug in the Portal Accelerator related to deploying the single platform subscription setup. Incorrect parameter settings led to the failure of AMBA, as it erroneously attempted to deploy to a standard management group structure instead of a single platform management group as needed.
+- Increasing Policy assignment delay by a couple of minutes to help reduce assignment errors using the portal accelerator experience (the infamous "please wait 30 minutes and try again" error).
 
 ### September 2024
 

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1075,7 +1075,7 @@
         },
         "delayCount": {
             "type": "int",
-            "defaultValue": 45,
+            "defaultValue": 55,
             "minValue": 1,
             "maxValue": 60,
             "metadata": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes a couple of changes aimed at improving the deployment process and reducing errors in the Azure Landing Zones project. The most important changes involve increasing the delay for policy assignments and updating the default delay count.

Improvements to deployment process:

* [`docs/wiki/Whats-new.md`](diffhunk://#diff-dc6403d6507d3ee6a1e907f047aa79fc3a0733256a2fdf5507a64ac754e7ff61R77): Increased the policy assignment delay by a couple of minutes to help reduce assignment errors using the portal accelerator experience.

Configuration updates:

* [`eslzArm/eslzArm.json`](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L1078-R1078): Updated the `delayCount` default value from 45 to 55 to align with the increased policy assignment delay.
