### PR TITLE
Fixes empty parameters for amba service hook and email contact

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -75,6 +75,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 
 - Resolved a bug in the Portal Accelerator related to deploying the single platform subscription setup. Incorrect parameter settings led to the failure of AMBA, as it erroneously attempted to deploy to a standard management group structure instead of a single platform management group as needed.
 - Increasing Policy assignment delay by a couple of minutes to help reduce assignment errors using the portal accelerator experience (the infamous "please wait 30 minutes and try again" error).
+- An issue with the Portal Accelerator regarding the Azure Monitor Baseline Alerts notifications settings was resolved. The problem occurred when no Email Address or Service Hook was specified on the Baseline alerts and monitoring tab. In this scenario, an empty string was converted to an array, resulting in the format `[""]` instead of `[]`. This caused errors during the remediation of the Notification Assets initiative.
 
 ### September 2024
 

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -2268,7 +2268,7 @@
                         "value": "[parameters('userAssignedManagedIdentityName')]"
                     },
                     "ALZWebhookServiceUri": {
-                        "value": "[array(parameters('ambaAgServiceHook'))]"
+                        "value": "[if(empty(parameters('ambaAgServiceHook')), null(), array(parameters('ambaAgServiceHook')))]"
                     },
                     "ALZArmRoleId": {
                         "value": "[array(parameters('ambaAgArmRole'))]"
@@ -2283,7 +2283,7 @@
                         "value": "[deployment().location]"
                     },
                     "ALZMonitorActionGroupEmail": {
-                        "value": "[array(parameters('ambaAgEmailContact'))]"
+                        "value": "[if(empty(parameters('ambaAgEmailContact')), null(), array(parameters('ambaAgEmailContact')))]"
                     },
                     "managementSubscriptionId": {
                         "value": "[parameters('managementSubscriptionId')]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request addresses an issue with the Portal Accelerator related to the Azure Monitor Baseline Alerts notification settings. The problem occurred when neither an email address nor a service hook was specified on the Baseline alerts and monitoring tab. In such cases, an empty string was being converted to an array in the format `[""]` rather than `[]`. This led to errors during the remediation of the Notification Assets initiative.

## This PR fixes/adds/changes/removes

1. Sets `ALZWebhookServiceUri` to null if `ambaAgServiceHook` is empty; otherwise, it uses the value of `ambaAgServiceHook`.
2. Sets `ALZMonitorActionGroupEmail` to null if `ambaAgEmailContact` is empty; otherwise, it uses the value of `ambaAgEmailContact`.


### Breaking Changes

None

## Testing Evidence

An empty string is now properly converted to an empty array during deployment.
![image](https://github.com/user-attachments/assets/f4c7ba48-8da6-40d6-8adc-f2cfcd191c80)

Remediation:

![image](https://github.com/user-attachments/assets/3903150d-9ddd-4a1b-9d6d-5985ecf973e9)


When a value is defined.
![image](https://github.com/user-attachments/assets/48b247d4-ca80-4805-b851-c54b71eca1df)



### Testing URLs

The below URLs can be updated where the placeholders are, look for `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}` & `{YOUR GITHUB BRANCH NAME HERE - Remove Curly Brackets Also}`, to allow you to test your portal deployment experience.

> Please also replace the curly brackets on the placeholders `{}`

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2F1792-amba-array-parameters%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2F1792-amba-array-parameters%2FeslzArm%2Feslz-portal.json)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
