### PR TITLE
Fixes deployment validation error when LAW is not deployed, and AMBA is enabled

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -1,6 +1,7 @@
 ## In this Section
 
 - [Updates](#updates)
+  - [November 2024](#november-2024)
   - [🔃 Policy Refresh Q1 FY25](#-policy-refresh-q1-fy25)
   - [October 2024](#october-2024)
   - [September 2024](#september-2024)
@@ -47,6 +48,12 @@ This article will be updated as and when changes are made to the above and anyth
 ## Updates
 
 Here's what's changed in Enterprise Scale/Azure Landing Zones:
+
+### November 2024
+
+#### Tooling
+
+- A bug was resolved in the Portal Accelerator that caused deployment validation to fail with the error message "The 'location' property must be specified for 'amba-id-amba-prod-001'". This event happened when a Log Analytics Workspace was not deployed, but Azure Monitor Baseline Alerts were enabled. This issue occurred because Azure Monitor Baseline Alerts depend on the management subscription, which is not provided if the Log Analytics Workspace is not deployed. To address this scenario, an additional section was implemented in the Baseline alerts and monitoring tab allowing the selection of a Management subscription when not deploying a Log Analytics Workspace.
 
 ### 🔃 Policy Refresh Q1 FY25
 

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -390,7 +390,6 @@
                                 }
                             ]
                         },
-                        
                         {
                             "name": "multiPlatformMgmtSub",
                             "type": "Microsoft.Common.InfoBox",
@@ -1243,6 +1242,41 @@
                                 }
                             ],
                             "visible": "[equals(steps('monitor').enableMonitorBaselines,'Yes')]"
+                        },
+                        {
+                            "name": "AmbaEsMgmtSubSection",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Management subscription",
+                            "elements": [
+                                {
+                                    "name": "AmbaEsMgmtSubUniqueWarningAmba",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": true,
+                                    "options": {
+                                        "text": "Ensure you select a subscription that is dedicated/unique for Management. Selecting the same Subscription here for Connectivity or Identity will result in a deployment failure. If you want to use a single Subscription for all platform resources, select 'Single' on the 'Azure Core Setup' blade.",
+                                        "uri": "https://learn.microsoft.com/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-subscriptions#organization-and-governance-design-considerations",
+                                        "style": "Warning"
+                                    }
+                                },
+                                {
+                                    "name": "AmbaEsMgmtSub",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Management subscription",
+                                    "defaultValue": "[parse('[]')]",
+                                    "toolTip": "",
+                                    "multiselect": false,
+                                    "selectAll": false,
+                                    "filter": true,
+                                    "filterPlaceholder": "Filter subscriptions...",
+                                    "multiLine": true,
+                                    "visible": true,
+                                    "constraints": {
+                                        "allowedValues": "[steps('basics').getSubscriptions.data]",
+                                        "required": true
+                                    }
+                                }
+                            ],
+                            "visible": "[and(equals(steps('management').enableLogAnalytics, 'No'), equals(steps('monitor').enableMonitorBaselines,'Yes'), not(equals(steps('core').platformSubscription, 'Single')))]"
                         },
                         {
                             "name": "esAmbaAgConfig",
@@ -4453,7 +4487,7 @@
                             },
                             "visible": "[and(equals(steps('identity').esIdentityConnectivity, 'Yes'), not(equals(steps('connectivity').enableHub,'No')))]"
                         },
-                        { 
+                        {
                             "name": "esIdentitySecondarySubSection",
                             "type": "Microsoft.Common.Section",
                             "label": "Secondary Region Identity",
@@ -4498,7 +4532,7 @@
                                     "visible": "[and(equals(steps('identity').esIdentitySecondarySubSection.esIdentityConnectivitySecondary, 'Yes'), not(equals(steps('connectivity').enableHub,'No')))]"
                                 }
                             ]
-                            }                      
+                            }
                     ]
                 },
                 {
@@ -9411,7 +9445,7 @@
                 "enableVmInsights": "[steps('management').enableVmInsights]",
                 "retentionInDays": "[string(steps('management').retentionInDays)]",
                 "enableSentinel": "[steps('management').enableSentinel]",
-                "managementSubscriptionId": "[steps('management').esMgmtSubSection.esMgmtSub]",
+                "managementSubscriptionId": "[if(and(equals(steps('management').enableLogAnalytics, 'No'), equals(steps('monitor').enableMonitorBaselines,'Yes'), not(equals(steps('core').platformSubscription, 'Single'))), steps('monitor').AmbaEsMgmtSubSection.AmbaEsMgmtSub, steps('management').esMgmtSubSection.esMgmtSub )]",
                 "enableAsc": "[steps('management').enableAsc]",
                 "emailContactAsc": "[steps('management').emailContactAsc]",
                 "enableAscForServers": "[steps('management').enableAscForServers]",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fixes a bug in the Portal Accelerator that causes deployment validation to fail with the error message "The 'location' property must be specified for 'amba-id-amba-prod-001'". This event happens when a Log Analytics Workspace is not deployed, but Azure Monitor Baseline Alerts is enabled. This issue occurs because Azure Monitor Baseline Alerts depends on the management subscription, which is not provided if the Log Analytics Workspace is not deployed. To address this scenario, an additional section was implemented in the Baseline alerts and monitoring tab allowing the selection of a Management subscription when not deploying a Log Analytics Workspace.

![image](https://github.com/user-attachments/assets/3308bd15-d7d2-4d88-998f-ed56423a3534)


## This PR fixes/adds/changes/removes

1. Added a new Management subscription section that is visible only if AMBA is deployed and LAW is not.
2. Updated logic for Management subscription output.


### Breaking Changes

None

## Testing Evidence

### Single subscription with LAW
Deployment
![image](https://github.com/user-attachments/assets/ba44631f-c008-4754-8127-03db897f50f5)

AMBA UAMI deployed to single platform subscription
![image](https://github.com/user-attachments/assets/afdb009e-7196-4304-90fd-85a4af67b0dc)


### Single subscription no LAW
Deployment
![image](https://github.com/user-attachments/assets/c0a7e761-b052-4b69-aec7-dbb33729e8c0)

AMBA UAMI deployed to single platform subscription
![image](https://github.com/user-attachments/assets/0d6c81b0-dd30-4877-9b08-0ade18e7a851)


### Dedicated subscriptions with LAW
Deployment
![image](https://github.com/user-attachments/assets/cd61214a-e21e-48e3-aa09-45206beecbed)

AMBA UAMI deployed to management subscription
![image](https://github.com/user-attachments/assets/69aa9500-8f50-4bfe-96f2-2ee52f66d418)


### Dedicated subscriptions no LAW, with Management subscription selection in Monitoring section
Deployment
![image](https://github.com/user-attachments/assets/fd6fb7c7-ae33-4047-9ead-c8e8b7a6d106)

AMBA UAMI deployed to management subscription
![image](https://github.com/user-attachments/assets/7425b2ce-650b-4176-98c5-fa44e48d0cf4)


### Dedicated subscriptions no LAW, no Management subscription selection in Monitoring section
Deployment
![image](https://github.com/user-attachments/assets/f23abfce-8180-495e-aa47-6d53cfb193af)

In this case the AMBA UAMI is not deployed.

### Testing URLs

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Farjenhuitema%2FEnterprise-Scale%2Ffix-no-law-breaks-amba%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Farjenhuitema%2FEnterprise-Scale%2Ffix-no-law-breaks-amba%2FeslzArm%2Feslz-portal.json)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
