### PR TITLE
fix: subscription-vending Bicep

### DIFF
--- a/docs/wiki/Create-Landingzones.md
+++ b/docs/wiki/Create-Landingzones.md
@@ -3,12 +3,13 @@
 The approach of "Subscription Vending", materializes and standardizes the ALZ "Subscription Democratization" Design Principle, by formulating a process for requesting, deploying and governing Azure Subscriptions, and by doing so enabling the Applications Teams to onboard their workloads in a fast, yet deterministic way.
 
 For further details, one can look into the following articles:
+
 - [Deploy Azure landing zones (Subscription Vending)](https://learn.microsoft.com/azure/architecture/landing-zones/landing-zone-deploy#subscription-vending)
 - [Subscription vending implementation guidance](https://learn.microsoft.com/azure/architecture/landing-zones/subscription-vending)
 
 The respective Bicep and Terraform automation / IaC Modules for Subscription Vending, can be found in:
 
-- [Bicep Subscription Vending](https://github.com/Azure/bicep-lz-vending)
+- [Bicep Subscription Vending](https://github.com/Azure/bicep-registry-modules/tree/main/avm/ptn/lz/sub-vending)
 - [Terraform Subscription Vending](https://registry.terraform.io/modules/Azure/lz-vending/azurerm/latest)
 
 More broader information on programmatical creation of Azure Subscriptions (EA/MCA/MPA) via the latest APIs, can be found on the following articles:

--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -56,6 +56,10 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 - A bug was resolved in the Portal Accelerator that caused deployment validation to fail with the error message "The 'location' property must be specified for 'amba-id-amba-prod-001'". This event happened when a Log Analytics Workspace was not deployed, but Azure Monitor Baseline Alerts were enabled. This issue occurred because Azure Monitor Baseline Alerts depend on the management subscription, which is not provided if the Log Analytics Workspace is not deployed. To address this scenario, an additional section was implemented in the Baseline alerts and monitoring tab allowing the selection of a Management subscription when not deploying a Log Analytics Workspace.
 - Updated the ***Baseline alerts and monitoring*** integration section in the portal accelerator to deploy the latest release of AMBA (2024-11-01). To read more on the changes, see the [What's new](https://aka.ms/amba/alz/whatsnew) page in the AMBA documentation.
 
+#### Documentation
+
+- Link for the Bicep Subscription Vending changed to AVM (Azure Verified Modules)
+
 ### 🔃 Policy Refresh Q1 FY25
 
 - Updated ALZ custom policies enforcing minimum TLS versions to properly evaluate the minimum TLS version, ensuring services configured to deploy TLS 1.3 will successfully evaluate.


### PR DESCRIPTION
## Overview/Summary

The link should point to the AVM module for Subscription vending.

## This PR fixes/adds/changes/removes

1. Changes the link to the AVM repository

Closes Azure/Azure-Landing-Zones#1651 

### Breaking Changes

none

## Testing Evidence


### Testing URLs


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [ ] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
