### PR TITLE
Update release URIs to point to the December 10, 2024 version

### DIFF
--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,5 +1,5 @@
 {
-    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2024-11-05",
-    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-11-05/eslzArm/eslzArm.json",
-    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-11-05/eslzArm/eslz-portal.json"
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2024-12-10",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-12-10/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2024-12-10/eslzArm/eslz-portal.json"
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Update release URIs to point to the December 10, 2024 version

## This PR fixes/adds/changes/removes

1. Update release URIs to point to the December 10, 2024 version


### Breaking Changes

## Testing Evidence

### Testing URLs

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [X] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
