### PR TITLE
docs: Add explanation on User-Assigned Managed Identities in ALZ policies to FAQ

### DIFF
--- a/docs/wiki/ALZ-Policies-FAQ.md
+++ b/docs/wiki/ALZ-Policies-FAQ.md
@@ -12,6 +12,14 @@ We've had a number of issues and pull requests submitted specifically around the
 
 The reason for this is that the policies and initiatives in this repo are intended to be used as part of the ALZ deployment process, and are used to generate the ARM templates that are deployed to Azure. The leading `[` character is required to support the generation of the ARM templates.
 
+### Why does ALZ not promote the usage of User-Assigned Managed Identities for Policy Assignments?
+
+Whilst User-Assigned Managed Identities for Policy Assignments are now supported, there are a number of reasons why ALZ does not promote the usage of them. 
+
+The primary risk is that the User-Assigned Managed Identity created and used for one or more policy assignments is an over-permissioned identity; both in terms of RBAC roles it has assigned to it and also the scope/s that it has been assigned to. With the focus on least privilege and zero trust security principles, we believe in ALZ that the use of a User-Assigned Managed Identity for policy assignments is not the best practice and instead you should continue to use the system-assigned managed identity for your Azure policy assignments.
+
+Not only does using a system-assigned managed identity for policy assignments reduce the risk of over-permissioning, but it also reduces the complexity of managing the identity and its RBAC permissions and assignments as the lifecycle of the system-assigned managed identity is managed by Azure policy automatically with the lifecycle of the policy assignment it is associated with.
+
 ### Diagnostic Settings v2 (December 2023)
 
 There are several issues raised around Diagnostic Settings, and we acknowledge that this is a complex area that is causing a lot of pain.


### PR DESCRIPTION
This pull request adds a new FAQ section to the `docs/wiki/ALZ-Policies-FAQ.md` file. The new section addresses the reasons why ALZ does not promote the usage of User-Assigned Managed Identities for Policy Assignments.

- Closes [AB#33051](https://dev.azure.com/CSUSolEng/2a9d5a5a-8998-4ad0-81c8-ef3045e4da97/_workitems/edit/33051)

Documentation updates:

* [`docs/wiki/ALZ-Policies-FAQ.md`](diffhunk://#diff-3949d7c2539c8b487c328cd56e3ad98df16a9f69af7a4a4d3b61456b84ffe095R15-R22): Added a new FAQ entry explaining the risks and reasons behind not promoting User-Assigned Managed Identities for Policy Assignments in ALZ.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
