### PR TITLE
Updating assignment name

### DIFF
--- a/eslzArm/managementGroupTemplates/policyAssignments/DENY-DINE-APPEND-TLS-SSL-PolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DENY-DINE-APPEND-TLS-SSL-PolicyAssignment.json
@@ -26,7 +26,7 @@
             "deployEncryptionInTransit": "[concat('/providers/Microsoft.Management/managementGroups/', parameters('topLevelManagementGroupPrefix'), '/providers/Microsoft.Authorization/policySetDefinitions/Enforce-EncryptTransit_20241211')]"
         },
         "policyAssignmentNames": {
-            "deployEncryptionInTransit": "Enforce-TLS-SSL-H224",
+            "deployEncryptionInTransit": "Enforce-TLS-SSL-Q225",
             "description": "Choose either Deploy if not exist and append in combination with audit or Select Deny in the Policy effect. Deny polices shift left. Deploy if not exist and append enforce but can be changed, and because missing existence condition require then the combination of Audit.",
             "displayName": "Deny or Deploy and append TLS requirements and SSL enforcement on resources without Encryption in transit"
         },


### PR DESCRIPTION
This pull request includes a small change to the `DENY-DINE-APPEND-TLS-SSL-PolicyAssignment.json` file. The change updates the `deployEncryptionInTransit` policy assignment name to reflect the new enforcement period.

* [`eslzArm/managementGroupTemplates/policyAssignments/DENY-DINE-APPEND-TLS-SSL-PolicyAssignment.json`](diffhunk://#diff-8d359919c8d0b0122d761dbe37f5b58fe560dca9373b1d661478292ae20c01adL29-R29): Updated `deployEncryptionInTransit` policy assignment name from "Enforce-TLS-SSL-H224" to "Enforce-TLS-SSL-Q225".