### PR TITLE
Workload Specific Compliance - Audit Only

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -65,6 +65,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 - Updated initiative [Enforce-EncryptTransit_20240509](https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Enforce-EncryptTransit_20240509.html) `AppServiceMinTlsVersion` parameter to include TLS version 1.3 (as supported by the policy).
 - Removed duplicate policy assignment "Container Apps should only be accessible over HTTPS" from initiative [Enforce-EncryptTransit_20241211](https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Enforce-EncryptTransit_2024.html). Note, this is a breaking change, and existing assignments should be removed and re-assigned.
 - Added new custom policies [Audit-Tags-Mandatory](https://www.azadvertizer.net/azpolicyadvertizer/Audit-Tags-Mandatory.html) and [Audit-Tags-Mandatory-Rg](https://www.azadvertizer.net/azpolicyadvertizer/Audit-Tags-Mandatory-Rg.html) to support auditing for the existence of mandatory tags (based on an array of tags). Not assigned by default.
+- Updated the Workload Specific Compliance initiative section in the portal accelerator to allow configuring `Audit Only` effect for workloads using the `DoNotEnforce` enforcement mode.
 
 ### December 2024
 

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -7492,7 +7492,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsNetworkInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsNetworkInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7590,7 +7590,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsKeyVaultSupInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsKeyVaultSupInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7688,7 +7688,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsStorageInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsStorageInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7786,7 +7786,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsAPIMInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsAPIMInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7878,7 +7878,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsAppServicesInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsAppServicesInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -5514,7 +5514,7 @@
                                     "filter": true,
                                     "filterPlaceholder": "Filter items ...",
                                     "multiLine": true,
-                                    "visible": "[equals(steps('workloadspecific').wlcAIReady.enableWsBotServiceInitiatives, 'Yes')]",
+                                    "visible": "[not(equals(steps('workloadspecific').wlcAIReady.enableWsBotServiceInitiatives, 'No'))]",
                                     "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                                     "constraints": {
                                         "allowedValues": [

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -5606,7 +5606,7 @@
                                     "filter": true,
                                     "filterPlaceholder": "Filter items ...",
                                     "multiLine": true,
-                                    "visible": "[equals(steps('workloadspecific').wlcAIReady.enableWsCognitiveServicesInitiatives, 'Yes')]",
+                                    "visible": "[not(equals(steps('workloadspecific').wlcAIReady.enableWsCognitiveServicesInitiatives, 'No'))]",
                                     "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                                     "constraints": {
                                         "allowedValues": [
@@ -5698,7 +5698,7 @@
                                     "filter": true,
                                     "filterPlaceholder": "Filter items ...",
                                     "multiLine": true,
-                                    "visible": "[equals(steps('workloadspecific').wlcAIReady.enableWsMachineLearningInitiatives, 'Yes')]",
+                                    "visible": "[not(equals(steps('workloadspecific').wlcAIReady.enableWsMachineLearningInitiatives, 'No'))]",
                                     "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                                     "constraints": {
                                         "allowedValues": [
@@ -5790,7 +5790,7 @@
                                     "filter": true,
                                     "filterPlaceholder": "Filter items ...",
                                     "multiLine": true,
-                                    "visible": "[equals(steps('workloadspecific').wlcAIReady.enableWsOpenAIInitiatives, 'Yes')]",
+                                    "visible": "[not(equals(steps('workloadspecific').wlcAIReady.enableWsOpenAIInitiatives, 'No'))]",
                                     "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                                     "constraints": {
                                         "allowedValues": [
@@ -5891,7 +5891,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsDataExplorerInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsDataExplorerInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -5983,7 +5983,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsDataFactoryInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsDataFactoryInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6075,7 +6075,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsSynapseInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsSynapseInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6173,7 +6173,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsComputeInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsComputeInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6265,7 +6265,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsVirtualDesktopInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsVirtualDesktopInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6363,7 +6363,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsContainerAppsInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsContainerAppsInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6455,7 +6455,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsContainerInstanceInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsContainerInstanceInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6547,7 +6547,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsContainerRegistryInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsContainerRegistryInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6639,7 +6639,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsKubernetesInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsKubernetesInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6737,7 +6737,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsCosmosDbInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsCosmosDbInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6829,7 +6829,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsMySQLInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsMySQLInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -6921,7 +6921,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsPostgreSQLInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsPostgreSQLInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7013,7 +7013,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsSQLInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsSQLInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7111,7 +7111,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsEventGridInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsEventGridInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7203,7 +7203,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsEventHubInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsEventHubInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7295,7 +7295,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsServiceBusInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsServiceBusInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [
@@ -7393,7 +7393,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[equals(steps('workloadspecific').enableWsAutomationInitiatives, 'Yes')]",
+                            "visible": "[not(equals(steps('workloadspecific').enableWsAutomationInitiatives, 'No'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -5414,7 +5414,7 @@
                                     "filter": true,
                                     "filterPlaceholder": "Filter items ...",
                                     "multiLine": true,
-                                    "visible": "[equals(steps('workloadspecific').wlcCMK.enableWsCMKInitiatives, 'Yes')]",
+                                    "visible": "[not(equals(steps('workloadspecific').wlcCMK.enableWsCMKInitiatives, 'No'))]",
                                     "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                                     "constraints": {
                                         "allowedValues": [

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -5871,6 +5871,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -5959,6 +5963,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -6045,6 +6053,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -6141,6 +6153,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -6227,6 +6243,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -6323,6 +6343,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -6409,6 +6433,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -6499,6 +6527,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -6585,6 +6617,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -6681,6 +6717,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -6767,6 +6807,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -6857,6 +6901,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -6943,6 +6991,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -7039,6 +7091,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -7127,6 +7183,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -7213,6 +7273,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -7307,6 +7371,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -7404,6 +7472,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -7496,6 +7568,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",
@@ -7592,6 +7668,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -7686,6 +7766,10 @@
                                         "value": "Yes"
                                     },
                                     {
+                                        "label": "Audit only",
+                                        "value": "Audit"
+                                    },
+                                    {
                                         "label": "No",
                                         "value": "No"
                                     }
@@ -7772,6 +7856,10 @@
                                     {
                                         "label": "Yes",
                                         "value": "Yes"
+                                    },
+                                    {
+                                        "label": "Audit only",
+                                        "value": "Audit"
                                     },
                                     {
                                         "label": "No",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -7492,7 +7492,7 @@
                             "filter": true,
                             "filterPlaceholder": "Filter items ...",
                             "multiLine": true,
-                            "visible": "[not(equals(steps('workloadspecific').enableWsNetworkInitiatives, 'No'))]",
+                            "visible": "[and(not(equals(steps('workloadspecific').enableWsNetworkInitiatives, 'No')), equals(steps('connectivity').enableDdoS, 'Yes'))]",
                             "defaultValue": [{"value": "contoso-platform"},{"value": "contoso-landingzones"}],
                             "constraints": {
                                 "allowedValues": [

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -5394,6 +5394,10 @@
                                                 "value": "Yes"
                                             },
                                             {
+                                                "label": "Audit only",
+                                                "value": "Audit"
+                                            },
+                                            {
                                                 "label": "No",
                                                 "value": "No"
                                             }
@@ -5490,6 +5494,10 @@
                                                 "value": "Yes"
                                             },
                                             {
+                                                "label": "Audit only",
+                                                "value": "Audit"
+                                            },
+                                            {
                                                 "label": "No",
                                                 "value": "No"
                                             }
@@ -5576,6 +5584,10 @@
                                             {
                                                 "label": "Yes",
                                                 "value": "Yes"
+                                            },
+                                            {
+                                                "label": "Audit only",
+                                                "value": "Audit"
                                             },
                                             {
                                                 "label": "No",
@@ -5666,6 +5678,10 @@
                                                 "value": "Yes"
                                             },
                                             {
+                                                "label": "Audit only",
+                                                "value": "Audit"
+                                            },
+                                            {
                                                 "label": "No",
                                                 "value": "No"
                                             }
@@ -5752,6 +5768,10 @@
                                             {
                                                 "label": "Yes",
                                                 "value": "Yes"
+                                            },
+                                            {
+                                                "label": "Audit only",
+                                                "value": "Audit"
                                             },
                                             {
                                                 "label": "No",

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -2841,7 +2841,7 @@
         },
         {
             // Assigning Workload Specific Customer Managed Keys Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsCMKInitiatives'), 'Yes'), not(empty(parameters('wsCMKSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsCMKInitiatives'), 'Yes'), equals(parameters('enableWsCMKInitiatives'), 'Audit')), not(empty(parameters('wsCMKSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsCMKDeploymentName, '-', replace(parameters('wsCMKSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -2882,13 +2882,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsCMKInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific APIM Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsAPIMInitiatives'), 'Yes'), not(empty(parameters('wsAPIMSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsAPIMInitiatives'), 'Yes'), equals(parameters('enableWsAPIMInitiatives'), 'Audit')), not(empty(parameters('wsAPIMSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsAPIMDeploymentName, '-', replace(parameters('wsAPIMSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -2929,13 +2932,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsAPIMInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific App Services Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsAppServicesInitiatives'), 'Yes'), not(empty(parameters('wsAppServicesSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsAppServicesInitiatives'), 'Yes'), equals(parameters('enableWsAppServicesInitiatives'), 'Audit')), not(empty(parameters('wsAppServicesSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsAppServicesDeploymentName, '-', replace(parameters('wsAppServicesSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -2976,13 +2982,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsAppServicesInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Automation Accounts Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsAutomationInitiatives'), 'Yes'), not(empty(parameters('wsAutomationSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsAutomationInitiatives'), 'Yes'), equals(parameters('enableWsAutomationInitiatives'), 'Audit')), not(empty(parameters('wsAutomationSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsAutomationDeploymentName, '-', replace(parameters('wsAutomationSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3023,13 +3032,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsAutomationInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Bot Service Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsBotServiceInitiatives'), 'Yes'), not(empty(parameters('wsBotServiceSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsBotServiceInitiatives'), 'Yes'), equals(parameters('enableWsBotServiceInitiatives'), 'Audit')), not(empty(parameters('wsBotServiceSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsBotServiceDeploymentName, '-', replace(parameters('wsBotServiceSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3070,13 +3082,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsBotServiceInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Cognitive Services Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsCognitiveServicesInitiatives'), 'Yes'), not(empty(parameters('wsCognitiveServicesSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsCognitiveServicesInitiatives'), 'Yes'), equals(parameters('enableWsCognitiveServicesInitiatives'), 'Audit')), not(empty(parameters('wsCognitiveServicesSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsCognitiveServicesDeploymentName, '-', replace(parameters('wsCognitiveServicesSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3117,13 +3132,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsCognitiveServicesInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Compute Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsComputeInitiatives'), 'Yes'), not(empty(parameters('wsComputeSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsComputeInitiatives'), 'Yes'), equals(parameters('enableWsComputeInitiatives'), 'Audit')), not(empty(parameters('wsComputeSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsComputeDeploymentName, '-', replace(parameters('wsComputeSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3164,13 +3182,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsComputeInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Container Apps Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsContainerAppsInitiatives'), 'Yes'), not(empty(parameters('wsContainerAppsSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsContainerAppsInitiatives'), 'Yes'), equals(parameters('enableWsContainerAppsInitiatives'), 'Audit')), not(empty(parameters('wsContainerAppsSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsContainerAppsDeploymentName, '-', replace(parameters('wsContainerAppsSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3211,13 +3232,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsContainerAppsInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Container Instance Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsContainerInstanceInitiatives'), 'Yes'), not(empty(parameters('wsContainerInstanceSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsContainerInstanceInitiatives'), 'Yes'), equals(parameters('enableWsContainerInstanceInitiatives'), 'Audit')), not(empty(parameters('wsContainerInstanceSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsContainerInstanceDeploymentName, '-', replace(parameters('wsContainerInstanceSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3258,13 +3282,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsContainerInstanceInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Container Registry Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsContainerRegistryInitiatives'), 'Yes'), not(empty(parameters('wsContainerRegistrySelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsContainerRegistryInitiatives'), 'Yes'), equals(parameters('enableWsContainerRegistryInitiatives'), 'Audit')), not(empty(parameters('wsContainerRegistrySelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsContainerRegistryDeploymentName, '-', replace(parameters('wsContainerRegistrySelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3305,13 +3332,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsContainerRegistryInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Cosmos DB Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsCosmosDbInitiatives'), 'Yes'), not(empty(parameters('wsCosmosDbSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsCosmosDbInitiatives'), 'Yes'), equals(parameters('enableWsCosmosDbInitiatives'), 'Audit')), not(empty(parameters('wsCosmosDbSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsCosmosDbDeploymentName, '-', replace(parameters('wsCosmosDbSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3352,13 +3382,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsCosmosDbInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Data Explorer Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsDataExplorerInitiatives'), 'Yes'), not(empty(parameters('wsDataExplorerSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsDataExplorerInitiatives'), 'Yes'), equals(parameters('enableWsDataExplorerInitiatives'), 'Audit')), not(empty(parameters('wsDataExplorerSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsDataExplorerDeploymentName, '-', replace(parameters('wsDataExplorerSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3399,13 +3432,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsDataExplorerInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Data Factory Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsDataFactoryInitiatives'), 'Yes'), not(empty(parameters('wsDataFactorySelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsDataFactoryInitiatives'), 'Yes'), equals(parameters('enableWsDataFactoryInitiatives'), 'Audit')), not(empty(parameters('wsDataFactorySelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsDataFactoryDeploymentName, '-', replace(parameters('wsDataFactorySelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3446,13 +3482,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsDataFactoryInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Event Grid Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsEventGridInitiatives'), 'Yes'), not(empty(parameters('wsEventGridSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsEventGridInitiatives'), 'Yes'), equals(parameters('enableWsEventGridInitiatives'), 'Audit')), not(empty(parameters('wsEventGridSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsEventGridDeploymentName, '-', replace(parameters('wsEventGridSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3493,13 +3532,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsEventGridInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Event Hub Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsEventHubInitiatives'), 'Yes'), not(empty(parameters('wsEventHubSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsEventHubInitiatives'), 'Yes'), equals(parameters('enableWsEventHubInitiatives'), 'Audit')), not(empty(parameters('wsEventHubSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsEventHubDeploymentName, '-', replace(parameters('wsEventHubSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3540,13 +3582,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsEventHubInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Key Vault Supplementary Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsKeyVaultSupInitiatives'), 'Yes'), not(empty(parameters('wsKeyVaultSupSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsKeyVaultSupInitiatives'), 'Yes'), equals(parameters('enableWsKeyVaultSupInitiatives'), 'Audit')), not(empty(parameters('wsKeyVaultSupSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsKeyVaultSupDeploymentName, '-', replace(parameters('wsKeyVaultSupSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3587,13 +3632,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsKeyVaultSupInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Kubernetes Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsKubernetesInitiatives'), 'Yes'), not(empty(parameters('wsKubernetesSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsKubernetesInitiatives'), 'Yes'), equals(parameters('enableWsKubernetesInitiatives'), 'Audit')), not(empty(parameters('wsKubernetesSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsKubernetesDeploymentName, '-', replace(parameters('wsKubernetesSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3634,13 +3682,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsKubernetesInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Machine Learning Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsMachineLearningInitiatives'), 'Yes'), not(empty(parameters('wsMachineLearningSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsMachineLearningInitiatives'), 'Yes'), equals(parameters('enableWsMachineLearningInitiatives'), 'Audit')), not(empty(parameters('wsMachineLearningSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsMachineLearningDeploymentName, '-', replace(parameters('wsMachineLearningSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3681,13 +3732,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsMachineLearningInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific MySQL Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsMySQLInitiatives'), 'Yes'), not(empty(parameters('wsMySQLSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsMySQLInitiatives'), 'Yes'), equals(parameters('enableWsMySQLInitiatives'), 'Audit')), not(empty(parameters('wsMySQLSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsMySQLDeploymentName, '-', replace(parameters('wsMySQLSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3728,13 +3782,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsMySQLInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Network and Networking services Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsNetworkInitiatives'), 'Yes'), not(empty(parameters('wsNetworkSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsNetworkInitiatives'), 'Yes'), equals(parameters('enableWsNetworkInitiatives'), 'Audit')), not(empty(parameters('wsNetworkSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsNetworkDeploymentName, '-', replace(parameters('wsNetworkSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3778,13 +3835,16 @@
                     },
                     "ddosPlanResourceId": {
                         "value": "[variables('platformResourceIds').ddosProtectionResourceId]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsNetworkInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific OpenAI Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsOpenAIInitiatives'), 'Yes'), not(empty(parameters('wsOpenAISelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsOpenAIInitiatives'), 'Yes'), equals(parameters('enableWsOpenAIInitiatives'), 'Audit')), not(empty(parameters('wsOpenAISelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsOpenAIDeploymentName, '-', replace(parameters('wsOpenAISelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3825,13 +3885,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsOpenAIInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific PostgreSQL Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsPostgreSQLInitiatives'), 'Yes'), not(empty(parameters('wsPostgreSQLSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsPostgreSQLInitiatives'), 'Yes'), equals(parameters('enableWsPostgreSQLInitiatives'), 'Audit')), not(empty(parameters('wsPostgreSQLSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsPostgreSQLDeploymentName, '-', replace(parameters('wsPostgreSQLSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3872,13 +3935,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsPostgreSQLInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Service Bus Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsServiceBusInitiatives'), 'Yes'), not(empty(parameters('wsServiceBusSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsServiceBusInitiatives'), 'Yes'), equals(parameters('enableWsServiceBusInitiatives'), 'Audit')), not(empty(parameters('wsServiceBusSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsServiceBusDeploymentName, '-', replace(parameters('wsServiceBusSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3919,13 +3985,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsServiceBusInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific SQL Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsSQLInitiatives'), 'Yes'), not(empty(parameters('wsSQLSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsSQLInitiatives'), 'Yes'), equals(parameters('enableWsSQLInitiatives'), 'Audit')), not(empty(parameters('wsSQLSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsSQLDeploymentName, '-', replace(parameters('wsSQLSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -3966,13 +4035,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsSQLInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Storage Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsStorageInitiatives'), 'Yes'), not(empty(parameters('wsStorageSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsStorageInitiatives'), 'Yes'), equals(parameters('enableWsStorageInitiatives'), 'Audit')), not(empty(parameters('wsStorageSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsStorageDeploymentName, '-', replace(parameters('wsStorageSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -4013,13 +4085,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsStorageInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Synapse Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsSynapseInitiatives'), 'Yes'), not(empty(parameters('wsSynapseSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsSynapseInitiatives'), 'Yes'), equals(parameters('enableWsSynapseInitiatives'), 'Audit')), not(empty(parameters('wsSynapseSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsSynapseDeploymentName, '-', replace(parameters('wsSynapseSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -4060,13 +4135,16 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsSynapseInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }
         },
         {
             // Assigning Workload Specific Virtual Desktop Initiaitve to selected management groups if condition is true
-            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), equals(parameters('enableWsVirtualDesktopInitiatives'), 'Yes'), not(empty(parameters('wsVirtualDesktopSelectorMG'))))]",
+            "condition": "[and(or(not(empty(parameters('singlePlatformSubscriptionId'))), not(empty(parameters('managementSubscriptionId')))), or(equals(parameters('enableWsVirtualDesktopInitiatives'), 'Yes'), equals(parameters('enableWsVirtualDesktopInitiatives'), 'Audit')), not(empty(parameters('wsVirtualDesktopSelectorMG'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
             "name": "[take(concat(variables('deploymentNames').wsVirtualDesktopDeploymentName, '-', replace(parameters('wsVirtualDesktopSelectorMG')[copyIndex()], 'contoso', parameters('enterpriseScaleCompanyPrefix'))), 64)]",
@@ -4107,6 +4185,9 @@
                     },
                     "assignmentIndex": {
                         "value": "[copyIndex()]"
+                    },
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enableWsVirtualDesktopInitiatives'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1529,7 +1529,7 @@
             "type": "array",
             "defaultValue": [],
             "metadata": {
-                "description": "Array of objects containing built-in Regulatory Compliance policies to assign to sepcfied Management Groups"
+                "description": "Array of objects containing built-in Regulatory Compliance policies to assign to specified Management Groups"
             }
         },
         "regCompPolParAusGovIsmRestrictedVmAdminsExclude": {

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1097,6 +1097,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1112,6 +1113,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1127,6 +1129,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1142,6 +1145,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1157,6 +1161,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1172,6 +1177,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1187,6 +1193,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1202,6 +1209,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1217,6 +1225,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1232,6 +1241,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1247,6 +1257,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1262,6 +1273,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1277,6 +1289,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1292,6 +1305,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1307,6 +1321,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1322,6 +1337,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1337,6 +1353,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1352,6 +1369,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1367,6 +1385,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1382,6 +1401,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1397,6 +1417,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1412,6 +1433,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1427,6 +1449,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1442,6 +1465,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1457,6 +1481,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1472,6 +1497,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"
@@ -1487,6 +1513,7 @@
             "type": "string",
             "allowedValues": [
                 "Yes",
+                "Audit",
                 "No"
             ],
             "defaultValue": "No"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes several changes to the `eslzArm/eslz-portal.json` file to enhance the visibility conditions and add a new "Audit only" option for various settings. The key changes are as follows:

### Visibility Condition Updates:
* Updated the `visible` property for multiple settings to use the condition `[not(equals(steps('workloadspecific').<setting>, 'No'))]` instead of `[equals(steps('workloadspecific').<setting>, 'Yes')]`. This change ensures that the settings are visible unless explicitly set to 'No'. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5413-R5417) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5509-R5517) [[3]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5597-R5609) [[4]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5685-R5701) [[5]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5773-R5793) [[6]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5870-R5894) [[7]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5958-R5986) [[8]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL6046-R6078) [[9]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL6140-R6176) [[10]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL6228-R6268) [[11]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL6322-R6366) [[12]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL6410-R6458) [[13]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL6498-R6550)

### Addition of "Audit only" Option:
* Added a new option with the label "Audit only" and value "Audit" to various settings, providing an additional selection for users. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5396-R5399) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5496-R5499) [[3]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5588-R5591) [[4]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5680-R5683) [[5]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5772-R5775) [[6]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5873-R5876) [[7]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5965-R5968) [[8]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6057-R6060) [[9]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6155-R6158) [[10]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6247-R6250) [[11]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6345-R6348) [[12]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6437-R6440) [[13]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6529-R6532) [[14]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6621-R6624)

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FAuditWS%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FAuditWS%2FeslzArm%2Feslz-portal.json)

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
