### PR TITLE
ES Lite Prereqs and AVNM support

### DIFF
--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -2460,7 +2460,7 @@
         },
         {
             // ALZ Pre-Requisites and Azure's Untold Story...
-            "condition": "[not(empty(parameters('managementSubscriptionId')))]",
+            "condition": "[or(not(empty(parameters('managementSubscriptionId'))), not(empty(parameters('singlePlatformSubscriptionId'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-06-01",
             "name": "alz-prerequisites",

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -5479,6 +5479,9 @@
                     },
                     "enableSecondaryRegion": {
                         "value": "[parameters('enableSecondaryRegion')]"
+                    },
+                    "dedicatedSubscription": {
+                        "value": false
                     }
                 }
             }

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -5351,7 +5351,7 @@
             "condition": "[and(parameters('deployAVNM'), or(equals(parameters('enableHub'), 'vhub'), equals(parameters('enableHub'), 'nva')), not(empty(parameters('singlePlatformSubscriptionId'))))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
-            "subscriptionId": "[parameters('connectivitySubscriptionId')]",
+            "subscriptionId": "[parameters('singlePlatformSubscriptionId')]",
             "name": "[variables('esLiteDeploymentNames').avnmLiteConnectivityHubDeploymentName]",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('deploymentNames').mgmtGroupDeploymentName)]",

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -2460,7 +2460,7 @@
         },
         {
             // ALZ Pre-Requisites and Azure's Untold Story...
-            "condition": "[or(not(empty(parameters('managementSubscriptionId'))), not(empty(parameters('singlePlatformSubscriptionId'))))]",
+            "condition": "[not(empty(parameters('managementSubscriptionId')))]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-06-01",
             "name": "alz-prerequisites",
@@ -2485,6 +2485,37 @@
                     },
                     "managementSubscriptionId": {
                         "value": "[parameters('managementSubscriptionId')]"
+                    }
+                }
+            }
+        },
+        {
+            // ALZ Pre-Requisites and Azure's Untold Story... LITE
+            "condition": "[not(empty(parameters('singlePlatformSubscriptionId')))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2020-06-01",
+            "name": "alz-prerequisites",
+            "scope": "[variables('scopes').eslzRootManagementGroup]",
+            "location": "[deployment().location]",
+            "dependsOn": [
+                "[variables('deploymentNames').initiativeDeploymentName]",
+                "[variables('esLiteDeploymentNames').mgmtGroupLiteDeploymentName]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "contentVersion": "1.0.0.0",
+                    "uri": "[variables('deploymentUris').preRequisites]"
+                },
+                "parameters": {
+                    "location": {
+                        "value": "[deployment().location]"
+                    },
+                    "eslzRootName": {
+                        "value": "[parameters('enterpriseScaleCompanyPrefix')]"
+                    },
+                    "managementSubscriptionId": {
+                        "value": "[parameters('singlePlatformSubscriptionId')]"
                     }
                 }
             }

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1991,6 +1991,8 @@
             "vnetConnectivityRouteTableDeploymentName": "[take(concat('alz-HubRoute', variables('deploymentSuffix')), 64)]",
             "vnetConnectivityRouteTable2DeploymentName": "[take(concat('alz-HubRoute2', variables('deploymentSuffix')), 64)]",
             "nvaConnectivityHubLite2DeploymentName": "[take(concat('alz-NVAHubLite2', variables('deploymentSuffix')), 64)]",
+            "avnmLiteConnectivityHubDeploymentName": "[take(concat('alz-AVNMLite', variables('deploymentSuffix')), 64)]",
+            "avnmLitePolicyDeploymentName": "[take(concat('alz-AVNMLitePolicy', variables('deploymentSuffix')), 64)]",
             "ddosRgLiteDeploymentName": "[take(concat('alz-DDoSRgLite', variables('deploymentSuffix')), 64)]",
             "ddosLiteDeploymentName": "[take(concat('alz-DDoSLite', variables('deploymentSuffix')), 64)]",
             "ddosHubLitePolicyDeploymentName": "[take(concat('alz-DDoSHubPolicyLite', variables('deploymentSuffix')), 64)]",
@@ -5345,6 +5347,46 @@
             }
         },
         {
+            // Deploy AVNM Lite
+            "condition": "[and(parameters('deployAVNM'), or(equals(parameters('enableHub'), 'vhub'), equals(parameters('enableHub'), 'nva')), not(empty(parameters('singlePlatformSubscriptionId'))))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2020-10-01",
+            "subscriptionId": "[parameters('connectivitySubscriptionId')]",
+            "name": "[variables('esLiteDeploymentNames').avnmLiteConnectivityHubDeploymentName]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', variables('deploymentNames').mgmtGroupDeploymentName)]",
+                "[resourceId('Microsoft.Resources/deployments', variables('esLiteDeploymentNames').mgmtGroupLiteDeploymentName)]",
+                "dnsZones",
+                "dnsZonesLite",
+                "alz-prerequisites"
+            ],
+            "location": "[deployment().location]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "contentVersion": "1.0.0.0",
+                    "uri": "[variables('deploymentUris').avnmConnectivityHub]"
+                },
+                "parameters": {
+                    "location": {
+                        "value": "[parameters('connectivityLocation')]"
+                    },
+                    "locationSecondary": {
+                        "value": "[parameters('connectivityLocationSecondary')]"
+                    },
+                    "managementGroupScope": {
+                        "value": "[variables('scopes').eslzRootManagementGroup]"
+                    },
+                    "connectivitySubscriptionId": {
+                        "value": "[parameters('singlePlatformSubscriptionId')]"
+                    },
+                    "enableSecondaryRegion": {
+                        "value": "[parameters('enableSecondaryRegion')]"
+                    }
+                }
+            }
+        },
+        {
             // Deploying AVNM policy - to add virtual networks to AVNM network groups
             "condition": "[and(parameters('deployAVNM'), or(equals(parameters('enableHub'), 'vhub'), equals(parameters('enableHub'), 'nva')), not(empty(parameters('connectivitySubscriptionId'))))]",
             "type": "Microsoft.Resources/deployments",
@@ -5367,6 +5409,39 @@
                     },
                     "connectivitySubscriptionId": {
                         "value": "[parameters('connectivitySubscriptionId')]"
+                    },
+                    "locationSecondary": {
+                        "value": "[parameters('connectivityLocationSecondary')]"
+                    },
+                    "enableSecondaryRegion": {
+                        "value": "[parameters('enableSecondaryRegion')]"
+                    }
+                }
+            }
+        },
+        {
+            // Deploying AVNM Lite policy - to add virtual networks to AVNM network groups
+            "condition": "[and(parameters('deployAVNM'), or(equals(parameters('enableHub'), 'vhub'), equals(parameters('enableHub'), 'nva')), not(empty(parameters('singlePlatformSubscriptionId'))))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "name": "[variables('esLiteDeploymentNames').avnmLitePolicyDeploymentName]",
+            "location": "[deployment().location]",
+            "scope": "[variables('scopes').eslzRootManagementGroup]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', variables('esLiteDeploymentNames').avnmLiteConnectivityHubDeploymentName)]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "contentVersion": "1.0.0.0",
+                    "uri": "[variables('deploymentUris').avnmPolicy]"
+                },
+                "parameters": {
+                    "topLevelManagementGroupPrefix": {
+                        "value": "[parameters('enterpriseScaleCompanyPrefix')]"
+                    },
+                    "connectivitySubscriptionId": {
+                        "value": "[parameters('singlePlatformSubscriptionId')]"
                     },
                     "locationSecondary": {
                         "value": "[parameters('connectivityLocationSecondary')]"

--- a/eslzArm/subscriptionTemplates/avnmConfiguration.json
+++ b/eslzArm/subscriptionTemplates/avnmConfiguration.json
@@ -591,7 +591,7 @@
                 }
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Resources/resourceGroups', variables('rgName'))]"
+                "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('rgName'))]"
             ]
             },
             {

--- a/eslzArm/subscriptionTemplates/avnmConfiguration.json
+++ b/eslzArm/subscriptionTemplates/avnmConfiguration.json
@@ -591,7 +591,7 @@
                 }
             },
             "dependsOn": [
-                "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('rgName'))]"
+                "[resourceId('Microsoft.Resources/resourceGroups', variables('rgName'))]"
             ]
             },
             {

--- a/eslzArm/subscriptionTemplates/avnmPolicy.json
+++ b/eslzArm/subscriptionTemplates/avnmPolicy.json
@@ -37,6 +37,13 @@
                 "description": "Enable secondary region for instances deploying in multiple regions"
             },
             "defaultValue": "No"
+        },
+        "dedicatedSubscription": {
+            "type": "bool",
+            "metadata": {
+                "description": "Dedicated subscriptions selected"
+            },
+            "defaultValue": true
         }
     },
     "variables": {
@@ -206,6 +213,7 @@
             ]
         },
         {
+            "condition": "[parameters('dedicatedSubscription')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "policyCorp",
@@ -363,6 +371,7 @@
             }
         },
         {
+            "condition": "[parameters('dedicatedSubscription')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "policyOnline",
@@ -520,6 +529,7 @@
             }
         },
         {
+            "condition": "[parameters('dedicatedSubscription')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "policyIdentity",
@@ -677,6 +687,7 @@
             }
         },
         {
+            "condition": "[parameters('dedicatedSubscription')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "policyManagement",
@@ -834,6 +845,7 @@
             }
         },
         {
+            "condition": "[parameters('dedicatedSubscription')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "policyConnectivity",
@@ -991,6 +1003,7 @@
             }
         },
         {
+            "condition": "[parameters('dedicatedSubscription')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "policySandbox",
@@ -1148,6 +1161,7 @@
             }
         },
         {
+            "condition": "[parameters('dedicatedSubscription')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "policyDecommissioned",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes several changes to the `eslzArm` templates to add support for AVNM Lite deployments and to introduce a new `dedicatedSubscription` parameter. The most important changes include the addition of new deployment names, new deployment conditions, and the introduction of the `dedicatedSubscription` parameter.

### Additions to AVNM Lite deployments:

* [`eslzArm/eslzArm.json`](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R1994-R1995): Added new deployment names for AVNM Lite and AVNM Lite policy.
* [`eslzArm/eslzArm.json`](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R2492-R2522): Added a new deployment for ALZ Pre-Requisites.
* [`eslzArm/eslzArm.json`](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R5380-R5419): Added a new deployment for AVNM Lite connectivity hub.
* [`eslzArm/eslzArm.json`](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R5453-R5488): Added a new deployment for AVNM Lite policy.

### Introduction of `dedicatedSubscription` parameter:

* [`eslzArm/subscriptionTemplates/avnmPolicy.json`](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR40-R46): Added the `dedicatedSubscription` parameter with a default value of `true`.
* [`eslzArm/subscriptionTemplates/avnmPolicy.json`](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR216): Added conditions to check the `dedicatedSubscription` parameter for various policy deployments. [[1]](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR216) [[2]](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR374) [[3]](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR532) [[4]](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR690) [[5]](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR848) [[6]](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR1006) [[7]](diffhunk://#diff-d9dd45963a016de2366189d8cad37703807cad968f1f019d36d17a5c17dc7d8aR1164)

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FesLiteAVNM%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FesLiteAVNM%2FeslzArm%2Feslz-portal.json)
