### PR TITLE
Update release.json

### DIFF
--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,5 +1,5 @@
 {
-    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-02-18",
-    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-02-18/eslzArm/eslzArm.json",
-    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-02-18/eslzArm/eslz-portal.json"
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-02-20",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-02-20/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-02-20/eslzArm/eslz-portal.json"
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/portal/release.json` file. The change updates the URIs to point to the latest version of the Azure Enterprise-Scale templates and form definitions.

* Updated `azureLandingZoneTemplateDetailsUri`, `templateUri`, and `uiFormDefinitionUri` to point to the 2025-02-20 version.