### PR TITLE
feat: Add definitionVersion property to PolicySetDefinitionPropertiesPolicyDefinitions class

### DIFF
--- a/src/Alz.Tools/Alz.Classes/Alz.Classes.psm1
+++ b/src/Alz.Tools/Alz.Classes/Alz.Classes.psm1
@@ -318,6 +318,7 @@ class PolicySetDefinitionPropertiesPolicyDefinitions : ALZBase {
     [String]$policyDefinitionId = ""
     [Object]$parameters = @{}
     [Array]$groupNames = @()
+    [String]$definitionVersion = ""
 
     PolicySetDefinitionPropertiesPolicyDefinitions(): base() {}
 
@@ -326,6 +327,7 @@ class PolicySetDefinitionPropertiesPolicyDefinitions : ALZBase {
         $this.policyDefinitionId = $that.policyDefinitionId
         $this.parameters = $that.parameters ?? $this.parameters
         $this.groupNames = $that.groupNames ?? $this.groupNames
+        $this.definitionVersion = $that.definitionVersion ?? $this.definitionVersion
     }
 
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add definitionVersion property to PolicySetDefinitionPropertiesPolicyDefinitions class in ALZ tools - needed for ALZ-Bicep policy sync process

## This PR fixes/adds/changes/removes

1.Add definitionVersion property to PolicySetDefinitionPropertiesPolicyDefinitions class in ALZ tools - needed for ALZ-Bicep policy sync process

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
