### PR TITLE
fix: missing output for MySql WSC in portal

### DIFF
--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -9943,6 +9943,8 @@
                 "wsNetworkSelectorMG": "[steps('workloadspecific').wsNetworkSelectorMG]",
                 "enableWsOpenAIInitiatives": "[steps('workloadspecific').wlcAIReady.enableWsOpenAIInitiatives]",
                 "wsOpenAISelectorMG": "[steps('workloadspecific').wlcAIReady.wsOpenAISelectorMG]",
+                "enableWsMySQLInitiatives": "[steps('workloadspecific').enableWsMySQLInitiatives]",
+                "wsMySQLSelectorMG": "[steps('workloadspecific').wsMySQLSelectorMG]",
                 "enableWsPostgreSQLInitiatives": "[steps('workloadspecific').enableWsPostgreSQLInitiatives]",
                 "wsPostgreSQLSelectorMG": "[steps('workloadspecific').wsPostgreSQLSelectorMG]",
                 "enableWsServiceBusInitiatives": "[steps('workloadspecific').enableWsServiceBusInitiatives]",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes a small change to the `eslzArm/eslz-portal.json` file. The change adds support for MySQL initiatives by including two new properties in the configuration.

* Added `enableWsMySQLInitiatives` property to support MySQL initiatives.
* Added `wsMySQLSelectorMG` property to specify the MySQL selector management group.