### PR TITLE
chore: update release.json URIs to 2025-04-08 version

### DIFF
--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,6 +1,6 @@
 {
-    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-03-21",
-    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-03-21/eslzArm/eslzArm.json",
-    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/main/eslzArm/eslzArm.json",
-    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-03-21/eslzArm/eslz-portal.json"
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-04-08",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-04-08/eslzArm/eslzArm.json",
+    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/2025-04-08/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-04-08/eslzArm/eslz-portal.json"
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

update release.json URIs to 2025-04-08

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
