### PR TITLE
Cloud selector removal + minor updates to Bastion/PDNSR

### DIFF
--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -9,7 +9,52 @@
                     "name": "basics",
                     "label": "Deployment settings",
                     "elements": [
-
+                        {
+                            "name": "cloudEnvironment",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Select cloud environment",
+                            "visible": false,  
+                            "elements": [
+                                {
+                                    "name": "selection",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": true,
+                                    "label": "Azure cloud environment",
+                                    "defaultValue": "[if(contains(steps('basics').resourceScope.location.name, 'china'), 'Azure China Cloud', if(contains(steps('basics').resourceScope.location.name, 'usgov'), 'Azure US Government', if(contains(steps('basics').resourceScope.location.name, 'usdod'), 'Azure US Government', 'Azure Cloud')))]",
+                                    "multiselect": false,
+                                    "selectAll": false,
+                                    "filter": false,
+                                    "multiLine": true,
+                                    "toolTip": "Select your target Azure cloud environment.",
+                                    "constraints": {
+                                        "allowedValues": [
+                                            {
+                                                "label": "Azure Cloud",
+                                                "value": "AzureCloud"
+                                            },
+                                            {
+                                                "label": "Azure China Cloud",
+                                                "value": "AzureChinaCloud"
+                                            },
+                                            {
+                                                "label": "Azure US Government",
+                                                "value": "AzureUSGovernment"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "warning",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": true,
+                                    "options": {
+                                        "icon": "Warning",
+                                        "text": "This value should be automatically set based on the list of available locations. Only change this if you believe the value to be incorrect.",
+                                        "uri": "https://docs.microsoft.com/en-us/cli/azure/manage-clouds-azure-cli"
+                                    }
+                                }
+                            ]
+                        },
                         {
                             "name": "resourceScope",
                             "type": "Microsoft.Common.ResourceScope"

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -12,13 +12,12 @@
                         {
                             "name": "cloudEnvironment",
                             "type": "Microsoft.Common.Section",
-                            "label": "Select cloud environment",
-                            "visible": false,  
+                            "label": "",
                             "elements": [
                                 {
                                     "name": "selection",
                                     "type": "Microsoft.Common.DropDown",
-                                    "visible": true,
+                                    "visible": false,
                                     "label": "Azure cloud environment",
                                     "defaultValue": "[if(contains(steps('basics').resourceScope.location.name, 'china'), 'Azure China Cloud', if(contains(steps('basics').resourceScope.location.name, 'usgov'), 'Azure US Government', if(contains(steps('basics').resourceScope.location.name, 'usdod'), 'Azure US Government', 'Azure Cloud')))]",
                                     "multiselect": false,
@@ -46,7 +45,7 @@
                                 {
                                     "name": "warning",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": true,
+                                    "visible": false,
                                     "options": {
                                         "icon": "Warning",
                                         "text": "This value should be automatically set based on the list of available locations. Only change this if you believe the value to be incorrect.",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -304,9 +304,9 @@
                                 {
                                     "name": "telemetryOptOut",
                                     "type": "Microsoft.Common.OptionsGroup",
-                                    "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
+                                    "visible": true,//"[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
                                     "label": "Customer Usage Selection Options",
-                                    "defaultValue": "[if(equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'), 'Enabled', 'Disabled')]",
+                                    "defaultValue": "Enabled",//"[if(equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'), 'Enabled', 'Disabled')]",
                                     "constraints": {
                                         "allowedValues": [
                                             {
@@ -322,7 +322,7 @@
                                     }
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true,//"[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
                         }
                     ]
                 },

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -692,7 +692,7 @@
                             "label": "Enable Microsoft Defender for Cloud for open-source relational databases",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for open-source relational databases.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -712,7 +712,7 @@
                             "label": "Enable Microsoft Defender for Cloud for Cosmos DB",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for Cosmos DB.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -732,7 +732,7 @@
                             "label": "Enable Microsoft Defender for Cloud for AppServices",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for AppServices.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -752,7 +752,7 @@
                             "label": "Enable Microsoft Defender for Cloud for Storage",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for Storage.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), or(equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'), equals(steps('basics').cloudEnvironment.selection, 'AzureUSGovernment')))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -792,7 +792,7 @@
                             "label": "Enable Microsoft Defender for Cloud for SQL servers on machines",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for SQL servers on virtual machines.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -812,7 +812,7 @@
                             "label": "Enable Microsoft Defender for Cloud for Key Vault",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for Key Vault.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -832,7 +832,7 @@
                             "label": "Enable Microsoft Defender for Cloud for Azure Resource Manager",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for Resource Manager.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), or(equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'), equals(steps('basics').cloudEnvironment.selection, 'AzureUSGovernment')))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -852,7 +852,7 @@
                             "label": "Enable Microsoft Defender for Cloud for APIs",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender for Cloud will be enabled for APIs.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), or(equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'), equals(steps('basics').cloudEnvironment.selection, 'AzureUSGovernment')))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -872,7 +872,7 @@
                             "label": "Enable Microsoft Defender CSPM",
                             "defaultValue": "Yes (recommended)",
                             "toolTip": "If 'Yes' is selected, Microsoft Defender CSPM will be enabled.<br>Uses the custom initiative <a href=\"https://www.azadvertizer.net/azpolicyinitiativesadvertizer/Deploy-MDFC-Config.html\">Deploy Microsoft Defender for Cloud configuration</a>.",
-                            "visible": "[and(equals(steps('management').enableAsc,'Yes'), or(equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'), equals(steps('basics').cloudEnvironment.selection, 'AzureUSGovernment')))]",
+                            "visible": "[equals(steps('management').enableAsc,'Yes')]",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -5381,7 +5381,7 @@
                                     "visible": true
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         },
                         {
                             "name": "corpOnlineSettingsInfo",
@@ -5597,7 +5597,7 @@
                                     "visible": true
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         },
                         {
                             "name": "onlineSection",
@@ -5643,7 +5643,7 @@
                                     }
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         }
                     ]
                 },
@@ -5778,7 +5778,7 @@
                                     }
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         },
                         {
                             "name": "wlcAIReady",
@@ -6182,7 +6182,7 @@
                                     }
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         },
                         {
                             "name": "wlcAnalytics",
@@ -8452,7 +8452,7 @@
                                 {
                                     "name": "decommSettingsInfo",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
+                                    "visible": true,
                                     "options": {
                                         "text": "The following policies will be enabled: <ul><li>Deny the deployment of new resources<li>Deploy an auto VM shutdown policy at UTC 00:00</ul>",
                                         "uri": "https://aka.ms/alz/policies",
@@ -8484,7 +8484,7 @@
                                     "visible": true
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         },
                         {
                             "name": "sandboxSection",
@@ -8494,7 +8494,7 @@
                                 {
                                     "name": "sandboxSettingsInfo",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
+                                    "visible": true,
                                     "options": {
                                         "text": "The following policies will be enabled: <ul><li>Deny vNET peering across subscriptions<li>Deny the deployment of vWAN/ER/VPN gateways</ul>",
                                         "uri": "https://aka.ms/alz/policies",
@@ -8526,7 +8526,7 @@
                                     "visible": true
                                 }
                             ],
-                            "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         }
                     ]
                 },

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -294,7 +294,7 @@
                                 {
                                     "name": "cuaSettingsInfo",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": "[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
+                                    "visible": true,//"[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
                                     "options": {
                                         "text": "Microsoft can identify the deployments of the Azure Resource Manager templates with the deployed Azure resources. Microsoft collects this information to provide the best experiences with their products and to operate their business. The telemetry is collected through customer usage attribution. The data is collected and governed by Microsoft's privacy policies, located at the trust center. Visit this link to find out more.",
                                         "uri": "https://github.com/Azure/Enterprise-Scale/wiki/Deploying-Enterprise-Scale-CustomerUsage",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -3225,7 +3225,7 @@
                             "type": "Microsoft.Common.OptionsGroup",
                             "label": "Deploy Bastion",
                             "defaultValue": "No",
-                            "visible": "[or(equals(steps('connectivity').enableHub, 'vhub'), equals(steps('connectivity').enableHub, 'nva'), equals(steps('connectivity').enableSidecarVnetPrimary, 'Yes'))]",
+                            "visible": "[and(or(equals(steps('connectivity').enableHub, 'vhub'), equals(steps('connectivity').enableHub, 'nva'), equals(steps('connectivity').enableSidecarVnetPrimary, 'Yes')),contains(split('canadacentral,centralus,eastus,eastus2,eastus2euap,westus2,mexicocentral,italynorth,norwayeast,northeurope,uksouth,westeurope,swedencentral,spaincentral,qatarcentral,israelcentral,southafricanorth,australiaeast,koreacentral', ','), steps('connectivity').connectivityLocation))]",
                             "toolTip": "If 'Yes' is selected when also adding a subscription for connectivity, ARM will deploy Azure Bastion (Standard and zone redundant) in the connectivity subscription.",
                             "constraints": {
                                 "allowedValues": [
@@ -4488,7 +4488,7 @@
                                     "type": "Microsoft.Common.OptionsGroup",
                                     "label": "Deploy Bastion",
                                     "defaultValue": "No",
-                                    "visible": "[or(equals(steps('connectivity').enableHub, 'vhub'), equals(steps('connectivity').enableHub, 'nva'), equals(steps('connectivity').esNetworkSecondarySubSection.enableSidecarVnetSecondary, 'Yes'))]",
+                                    "visible": "[and(or(equals(steps('connectivity').enableHub, 'vhub'), equals(steps('connectivity').enableHub, 'nva'), equals(steps('connectivity').esNetworkSecondarySubSection.enableSidecarVnetSecondary, 'Yes')),contains(split('canadacentral,centralus,eastus,eastus2,eastus2euap,westus2,mexicocentral,italynorth,norwayeast,northeurope,uksouth,westeurope,swedencentral,spaincentral,qatarcentral,israelcentral,southafricanorth,australiaeast,koreacentral', ','), steps('connectivity').esNetworkSecondarySubSection.connectivityLocationSecondary))]",
                                     "toolTip": "If 'Yes' is selected when also adding a subscription for connectivity, ARM will deploy Azure Bastion (Standard and zone redundant) in the connectivity subscription.",
                                     "constraints": {
                                         "allowedValues": [

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -13,7 +13,7 @@
                             "name": "cloudEnvironment",
                             "type": "Microsoft.Common.Section",
                             "label": "Select cloud environment",
-                            "visible": false,
+                            "visible": false,  
                             "elements": [
                                 {
                                     "name": "selection",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -13,7 +13,7 @@
                             "name": "cloudEnvironment",
                             "type": "Microsoft.Common.Section",
                             "label": "Select cloud environment",
-                            "visible": true,
+                            "visible": false,
                             "elements": [
                                 {
                                     "name": "selection",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -17,7 +17,7 @@
                                 {
                                     "name": "selection",
                                     "type": "Microsoft.Common.DropDown",
-                                    "visible": true,
+                                    "visible": false,
                                     "label": "Azure cloud environment",
                                     "defaultValue": "[if(contains(steps('basics').resourceScope.location.name, 'china'), 'Azure China Cloud', if(contains(steps('basics').resourceScope.location.name, 'usgov'), 'Azure US Government', if(contains(steps('basics').resourceScope.location.name, 'usdod'), 'Azure US Government', 'Azure Cloud')))]",
                                     "multiselect": false,
@@ -45,7 +45,7 @@
                                 {
                                     "name": "warning",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": true,
+                                    "visible": false,
                                     "options": {
                                         "icon": "Warning",
                                         "text": "This value should be automatically set based on the list of available locations. Only change this if you believe the value to be incorrect.",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -294,7 +294,7 @@
                                 {
                                     "name": "cuaSettingsInfo",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": true,//"[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
+                                    "visible": true,
                                     "options": {
                                         "text": "Microsoft can identify the deployments of the Azure Resource Manager templates with the deployed Azure resources. Microsoft collects this information to provide the best experiences with their products and to operate their business. The telemetry is collected through customer usage attribution. The data is collected and governed by Microsoft's privacy policies, located at the trust center. Visit this link to find out more.",
                                         "uri": "https://github.com/Azure/Enterprise-Scale/wiki/Deploying-Enterprise-Scale-CustomerUsage",
@@ -304,9 +304,9 @@
                                 {
                                     "name": "telemetryOptOut",
                                     "type": "Microsoft.Common.OptionsGroup",
-                                    "visible": true,//"[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]",
+                                    "visible": true,
                                     "label": "Customer Usage Selection Options",
-                                    "defaultValue": "Enabled",//"[if(equals(steps('basics').cloudEnvironment.selection, 'AzureCloud'), 'Enabled', 'Disabled')]",
+                                    "defaultValue": "Enabled",
                                     "constraints": {
                                         "allowedValues": [
                                             {
@@ -322,7 +322,7 @@
                                     }
                                 }
                             ],
-                            "visible": true,//"[equals(steps('basics').cloudEnvironment.selection, 'AzureCloud')]"
+                            "visible": true
                         }
                     ]
                 },

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -13,7 +13,7 @@
                             "name": "cloudEnvironment",
                             "type": "Microsoft.Common.Section",
                             "label": "Select cloud environment",
-                            "visible": false,
+                            "visible": true,
                             "elements": [
                                 {
                                     "name": "selection",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -13,11 +13,12 @@
                             "name": "cloudEnvironment",
                             "type": "Microsoft.Common.Section",
                             "label": "Select cloud environment",
+                            "visible": false,
                             "elements": [
                                 {
                                     "name": "selection",
                                     "type": "Microsoft.Common.DropDown",
-                                    "visible": false,
+                                    "visible": true,
                                     "label": "Azure cloud environment",
                                     "defaultValue": "[if(contains(steps('basics').resourceScope.location.name, 'china'), 'Azure China Cloud', if(contains(steps('basics').resourceScope.location.name, 'usgov'), 'Azure US Government', if(contains(steps('basics').resourceScope.location.name, 'usdod'), 'Azure US Government', 'Azure Cloud')))]",
                                     "multiselect": false,
@@ -45,7 +46,7 @@
                                 {
                                     "name": "warning",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": false,
+                                    "visible": true,
                                     "options": {
                                         "icon": "Warning",
                                         "text": "This value should be automatically set based on the list of available locations. Only change this if you believe the value to be incorrect.",

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -9,52 +9,7 @@
                     "name": "basics",
                     "label": "Deployment settings",
                     "elements": [
-                        {
-                            "name": "cloudEnvironment",
-                            "type": "Microsoft.Common.Section",
-                            "label": "Select cloud environment",
-                            "visible": false,  
-                            "elements": [
-                                {
-                                    "name": "selection",
-                                    "type": "Microsoft.Common.DropDown",
-                                    "visible": true,
-                                    "label": "Azure cloud environment",
-                                    "defaultValue": "[if(contains(steps('basics').resourceScope.location.name, 'china'), 'Azure China Cloud', if(contains(steps('basics').resourceScope.location.name, 'usgov'), 'Azure US Government', if(contains(steps('basics').resourceScope.location.name, 'usdod'), 'Azure US Government', 'Azure Cloud')))]",
-                                    "multiselect": false,
-                                    "selectAll": false,
-                                    "filter": false,
-                                    "multiLine": true,
-                                    "toolTip": "Select your target Azure cloud environment.",
-                                    "constraints": {
-                                        "allowedValues": [
-                                            {
-                                                "label": "Azure Cloud",
-                                                "value": "AzureCloud"
-                                            },
-                                            {
-                                                "label": "Azure China Cloud",
-                                                "value": "AzureChinaCloud"
-                                            },
-                                            {
-                                                "label": "Azure US Government",
-                                                "value": "AzureUSGovernment"
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "name": "warning",
-                                    "type": "Microsoft.Common.InfoBox",
-                                    "visible": true,
-                                    "options": {
-                                        "icon": "Warning",
-                                        "text": "This value should be automatically set based on the list of available locations. Only change this if you believe the value to be incorrect.",
-                                        "uri": "https://docs.microsoft.com/en-us/cli/azure/manage-clouds-azure-cli"
-                                    }
-                                }
-                            ]
-                        },
+
                         {
                             "name": "resourceScope",
                             "type": "Microsoft.Common.ResourceScope"

--- a/eslzArm/subscriptionTemplates/bastion.json
+++ b/eslzArm/subscriptionTemplates/bastion.json
@@ -344,7 +344,7 @@
                             "name": "[parameters('bastionHostName')]",
                             "location": "[parameters('location')]",
                             "sku": {
-                                "name": "Standard"
+                                "name": "Premium"
                             },
                             "zones": [
                                 "1",

--- a/eslzArm/subscriptionTemplates/privateDnsResolver.json
+++ b/eslzArm/subscriptionTemplates/privateDnsResolver.json
@@ -9,20 +9,6 @@
                 "description": "Name of new or existing vnet to which Azure Bastion should be deployed"
             }
         },
-        "resolverVnetIpPrefix": {
-            "type": "string",
-            "defaultValue": "10.100.0.0/16",
-            "metadata": {
-                "description": "IP prefix for available addresses in vnet address space"
-            }
-        },
-        "resolverSubnetIpPrefix": {
-            "type": "string",
-            "defaultValue": "10.100.9.0/26",
-            "metadata": {
-                "description": "Bastion subnet IP prefix MUST be within vnet IP prefix address space"
-            }
-        },
         "location": {
             "type": "string",
             "defaultValue": "[resourceGroup().location]",
@@ -102,36 +88,6 @@
                 "description": "name of the forwarding ruleset"
             }
         },
-        "forwardingRuleName": {
-            "type": "string",
-            "defaultValue": "contosocom",
-            "metadata": {
-                "description": "name of the forwarding rule name"
-            }
-        },
-        "DomainName": {
-            "type": "string",
-            "defaultValue": "contoso.com.",
-            "metadata": {
-                "description": "the target domain name for the forwarding ruleset"
-            }
-        },
-        "targetDNS": {
-            "type": "array",
-            "defaultValue": [
-                {
-                "ipaddress": "10.0.0.4",
-                "port": 53
-                },
-                {
-                "ipaddress": "10.0.0.5",
-                "port": 53
-                }
-            ],
-            "metadata": {
-                "description": "the list of target DNS servers ip address and the port number for conditional forwarding"
-            }
-        },
         "topLevelManagementGroupPrefix": {
             "type": "string",
             "metadata": {
@@ -190,15 +146,6 @@
                     },
                     "resolvervnetlink": {
                         "value": "[parameters('resolvervnetlink')]"
-                    },
-                    "forwardingRuleName": {
-                        "value": "[parameters('forwardingRuleName')]"
-                    },
-                    "DomainName": {
-                        "value": "[parameters('DomainName')]"
-                    },
-                    "targetDNS": {
-                        "value": "[parameters('targetDNS')]"
                     }
                 },
                 "template": {
@@ -231,15 +178,6 @@
                         },
                         "resolvervnetlink": {
                             "type": "string"
-                        },
-                        "forwardingRuleName": {
-                            "type": "string"
-                        },
-                        "DomainName": {
-                            "type": "string"
-                        },
-                        "targetDNS": {
-                            "type": "array"
                         }
                     },
                     "variables": {
@@ -604,18 +542,6 @@
                                 "virtualNetwork": {
                                     "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('resolverVNETName'))]"
                                 }
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Network/dnsForwardingRulesets', parameters('forwardingRulesetName'))]"
-                            ]
-                        },
-                        {
-                            "type": "Microsoft.Network/dnsForwardingRulesets/forwardingRules",
-                            "apiVersion": "2022-07-01",
-                            "name": "[format('{0}/{1}', parameters('forwardingRulesetName'), parameters('forwardingRuleName'))]",
-                            "properties": {
-                                "domainName": "[parameters('DomainName')]",
-                                "targetDnsServers": "[parameters('targetDNS')]"
                             },
                             "dependsOn": [
                                 "[resourceId('Microsoft.Network/dnsForwardingRulesets', parameters('forwardingRulesetName'))]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request modifies the `eslzArm/eslz-portal.json` file to simplify visibility conditions and improve user experience. The changes primarily focus on removing conditional logic tied to the cloud environment and ensuring consistent visibility for certain UI elements.

### Simplification of visibility conditions:
* Replaced complex visibility conditions, such as those dependent on `cloudEnvironment.selection`, with a constant `true` value for multiple UI elements, including `cuaSettingsInfo`, `telemetryOptOut`, and various sections. This ensures these elements are always visible. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL297-R297) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL307-R309) [[3]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL325-R325) [[4]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5384-R5384) [[5]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5600-R5600) [[6]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5646-R5646) [[7]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL5781-R5781) [[8]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL6185-R6185) [[9]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL8455-R8455) [[10]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL8487-R8487)

* Updated visibility conditions for Microsoft Defender for Cloud options to depend solely on `enableAsc` rather than both `enableAsc` and `cloudEnvironment.selection`. This simplifies the logic and broadens applicability. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL695-R695) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL715-R715) [[3]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL735-R735) [[4]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL755-R755) [[5]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL795-R795) [[6]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL815-R815) [[7]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL835-R835) [[8]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL855-R855) [[9]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL875-R875)

### Enhanced logic for Bastion deployment:
* Refined the visibility logic for Bastion deployment options to include additional location-based constraints, ensuring that Bastion is only deployed in supported regions. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL3228-R3228) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL4491-R4491)

### UI improvements:
* Removed the label for the `cloudEnvironment` section and set its visibility to `false`, effectively hiding it from the UI. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL15-R20) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fL48-R48)

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#view/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FCloudSelectorRemoval%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FSpringstone%2FEnterprise-Scale%2FCloudSelectorRemoval%2FeslzArm%2Feslz-portal.json)
