### PR TITLE
Update release URIs to version 2025-07-03

### DIFF
--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,6 +1,6 @@
 {
-    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-06-12",
-    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-06-12/eslzArm/eslzArm.json",
-    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/2025-06-12/eslzArm/eslzArm.json",
-    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-06-12/eslzArm/eslz-portal.json"
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-07-03",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-07-03/eslzArm/eslzArm.json",
+    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/2025-07-03/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-07-03/eslzArm/eslz-portal.json"
 }


### PR DESCRIPTION
## Overview/Summary

Update release URIs to version 2025-07-03

## This PR fixes/adds/changes/removes

1. Update release URIs to version 2025-07-03


### Breaking Changes
N/A

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
