### PR TITLE
Correcting Service Health policy version in assingment

### DIFF
--- a/eslzArm/managementGroupTemplates/policyAssignments/DINE-ServiceHealthBuiltInPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DINE-ServiceHealthBuiltInPolicyAssignment.json
@@ -31,7 +31,7 @@
     "variables": {
         "policyDefinitions": {
             "deploySvcHealthBuiltIn": "/providers/Microsoft.Authorization/policyDefinitions/98903777-a9f6-47f5-90a9-acaf62ab01a8",
-            "policyVersion": "1.*.*"
+            "policyVersion": "1.*.*-preview"
         },
         "policyAssignmentNames": {
             "svcHealthBuiltIn": "Deploy-SvcHealth-BuiltIn",


### PR DESCRIPTION
This pull request updates the version of the Service Health Built-In policy definition in the `DINE-ServiceHealthBuiltInPolicyAssignment.json` file to use a preview version.

Non-existent policy version was being assigned.

Policy version update:

* Changed the `policyVersion` variable from `"1.*.*"` to `"1.*.*-preview"` to reference the preview version of the Service Health Built-In policy definition.