### PR TITLE
Update release URIs to version 2025-09-17

### DIFF
--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,6 +1,6 @@
 {
-    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-09-09",
-    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-09-09/eslzArm/eslzArm.json",
-    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/2025-09-09/eslzArm/eslzArm.json",
-    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-09-09/eslzArm/eslz-portal.json"
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-09-17",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-09-17/eslzArm/eslzArm.json",
+    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/2025-09-17/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-09-17/eslzArm/eslz-portal.json"
 }


### PR DESCRIPTION
This pull request updates the release configuration to reference the latest Azure Enterprise-Scale template version. This ensures that deployments and UI definitions use the most current resources.

Release configuration update:

* Updated all template and UI definition URIs in `src/portal/release.json` to point to the `2025-09-17` version of the Azure Enterprise-Scale repository and files.