### PR TITLE
fix: remove ability for test-portal to run from 3rd party PRs

### DIFF
--- a/.github/workflows/test-portal.yml
+++ b/.github/workflows/test-portal.yml
@@ -33,7 +33,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: test-${{ github.event.pull_request.head.repo.full_name }}/${{ github.head_ref || github.run_id }}
+  group: test-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 ###############
@@ -48,16 +48,14 @@ jobs:
     if: |
       (
         github.event.pull_request.head.repo.full_name == 'Azure/Enterprise-Scale'
-      )
-      ||
-      (
-        github.event.pull_request.head.repo.full_name != 'Azure/Enterprise-Scale'
         &&
-        contains(github.event.pull_request.labels.*.name, 'PR: Safe to test :test_tube:')
+        github.event_name == 'pull_request'
       )
       ||
       (
         github.event_name == 'workflow_dispatch'
+        &&
+        startsWith(github.ref, 'refs/heads/')
       )
       ||
       (
@@ -68,11 +66,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
-
-      - name: Show env
-        run: env | sort
 
       - name: List available pwsh modules
         uses: azure/powershell@53dd145408794f7e80f97cfcca04155c85234709 # v2.0.0

--- a/.github/workflows/test-portal.yml
+++ b/.github/workflows/test-portal.yml
@@ -43,6 +43,7 @@ jobs:
   test-portal:
     name: Test Portal Experience
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     environment: csu-rw
     if: |
       (


### PR DESCRIPTION
Simplify test portal workflow so that it only runs for:

- PRs from this repo
- Workflow dispatch for branches in this repo
- Merge group

We no longer support running the portal test from forks so do not need the label. This is part of a defence in depth strategy in line with other safeguards.