### PR TITLE
Portal updates enhancements

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -1,6 +1,7 @@
 ## In this Section
 
 - [Updates](#updates)
+  - [December 2025](#december-2025)
   - [November 2025](#november-2025)
   - [October 2025](#october-2025)
   - [September 2025](#september-2025)
@@ -61,11 +62,17 @@ This article will be updated as and when changes are made to the above and anyth
 
 Here's what's changed in Enterprise Scale/Azure Landing Zones:
 
-### November 2025
+### December 2025
 
 #### Tooling
 
 - Implemented default Cloud Adoption Framework (CAF) naming standards across all resources. In addition, you now have the flexibility to apply custom naming conventions to suit your unique organizational requirements.
+- The portal accelerator now deploys all SKUs of Azure Firewall with the [management NIC](https://learn.microsoft.com/azure/firewall/management-nic) to route its management traffic via the AzureFirewallManagementSubnet.
+- **NEW** ALZ Portal Accelerator:
+  - Added support for Bastion and Private DNS Resolver in the portal experience. These can be selected in the networking section of the portal experience.
+  - For Private DNS Resolver, last mile configuration is required. This requires configuring forwarding rules to your own domain. By default peered networks are not configured to use the Private DNS Resolver. Please see [Private DNS Resolver documentation](https://learn.microsoft.com/azure/dns/resolver/overview) for more information, these need to be updated once Private DNS Resolver is fully configured.
+
+### November 2025
 
 #### Other
 
@@ -76,15 +83,6 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 #### Tooling
 
 - Updated the ***Baseline alerts and monitoring*** integration section in the portal accelerator to deploy the latest release of AMBA (2025-010-01). To read more on the changes, see the [What's new](https://aka.ms/amba/alz/whatsnew) page in the AMBA documentation.
-
-### October 2025
-
-#### Tooling
-
-- Updated the ***Baseline alerts and monitoring*** integration section in the portal accelerator to deploy the latest release of AMBA (2025-010-01). To read more on the changes, see the [What's new](https://aka.ms/amba/alz/whatsnew) page in the AMBA documentation.
-- Portal experience:
-  - Added support for Bastion and Private DNS Resolver in the portal experience. These can be selected in the networking section of the portal experience.
-  - For Private DNS Resolver, last mile configuration is required. This requires configuring forwarding rules to your own dommain. By default peered networks are not configured to use the Private DNS Resolver. Please see [Private DNS Resolver documentation](https://learn.microsoft.com/azure/dns/resolver/overview) for more information, these need to be updated once Private DNS Resolver is fully configured.
 
 ### September 2025
 
@@ -148,10 +146,7 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 
 #### Tooling
 
-- **NEW** ALZ Portal Accelerator - adding new networking options to deploy "Bastion" and/or "Private DNS Resovler"
-  - For "Private DNS Resolver" we are deploying a default forwarding rule to `contoso.com` domain. This is a placeholder and should be updated to your own domain once ExpressRoutes or VPN sites are configured.
 - Updated the ***Baseline alerts and monitoring*** integration section in the portal accelerator to deploy the latest release of AMBA (2025-03-03). To read more on the changes, see the [What's new](https://aka.ms/amba/alz/whatsnew) page in the AMBA documentation.
-- The portal accelerator now deploys all SKUs of Azure Firewall with the [management NIC](https://learn.microsoft.com/azure/firewall/management-nic) to route its management traffic via the AzureFirewallManagementSubnet.
 - The Workload Specific Compliance policies are now assigned by default (Audit). This enables auditing compliance for specific workloads, such as SQL and Storage, which is often required in highly regulated industries like financial services and healthcare. Please note that these policies were previously available; however, they were not assigned by default.
 
 ### February 2025

--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -3804,7 +3804,7 @@
                             "label": "Deploy Bastion",
                             "defaultValue": "No",
                             "visible": "[and(or(equals(steps('connectivity').enableHub, 'vhub'), equals(steps('connectivity').enableHub, 'nva'), equals(steps('connectivity').enableSidecarVnetPrimary, 'Yes')),contains(split('canadacentral,centralus,eastus,eastus2,eastus2euap,westus2,mexicocentral,italynorth,norwayeast,northeurope,uksouth,westeurope,swedencentral,spaincentral,qatarcentral,israelcentral,southafricanorth,australiaeast,koreacentral', ','), steps('connectivity').connectivityLocation))]",
-                            "toolTip": "If 'Yes' is selected when also adding a subscription for connectivity, ARM will deploy Azure Bastion (Standard and zone redundant) in the connectivity subscription.",
+                            "toolTip": "If 'Yes' is selected when also adding a subscription for connectivity, ARM will deploy Azure Bastion (zone redundant) in the connectivity subscription.",
                             "constraints": {
                                 "allowedValues": [
                                     {
@@ -3814,6 +3814,34 @@
                                     {
                                         "label": "No",
                                         "value": "No"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "bastionPrimarySku",
+                            "type": "Microsoft.Common.DropDown",
+                            "label": "Bastion SKU",
+                            "defaultValue": "Premium (default)",
+                            "multiselect": false,
+                            "selectAll": false,
+                            "filter": false,
+                            "multiLine": true,
+                            "visible": "[equals(steps('connectivity').enableBastionPrimary, 'Yes')]",
+                            "toolTip": "Bastion SKU selection: <a href=\"https://learn.microsoft.com/en-us/azure/bastion/bastion-overview\">Azure Bastion Overview</a>.",
+                            "constraints": {
+                                "allowedValues": [
+                                    {
+                                        "label": "Premium (default)",
+                                        "value": "Premium"
+                                    },
+                                    {
+                                        "label": "Standard",
+                                        "value": "Standard"
+                                    },
+                                    {
+                                        "label": "Basic",
+                                        "value": "Basic"
                                     }
                                 ]
                             }
@@ -5209,6 +5237,34 @@
                                             {
                                                 "label": "No",
                                                 "value": "No"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "bastionSecondarySku",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Bastion SKU",
+                                    "defaultValue": "Premium (default)",
+                                    "multiselect": false,
+                                    "selectAll": false,
+                                    "filter": false,
+                                    "multiLine": true,
+                                    "visible": "[equals(steps('connectivity').esNetworkSecondarySubSection.enableBastionSecondary, 'Yes')]",
+                                    "toolTip": "Bastion SKU selection: <a href=\"https://learn.microsoft.com/en-us/azure/bastion/bastion-overview\">Azure Bastion Overview</a>.",
+                                    "constraints": {
+                                        "allowedValues": [
+                                            {
+                                                "label": "Premium (default)",
+                                                "value": "Premium"
+                                            },
+                                            {
+                                                "label": "Standard",
+                                                "value": "Standard"
+                                            },
+                                            {
+                                                "label": "Basic",
+                                                "value": "Basic"
                                             }
                                         ]
                                     }
@@ -10933,8 +10989,10 @@
                 "deployAVNM": "[steps('connectivity').deployAVNM]",
                 "enableBastionPrimary": "[steps('connectivity').enableBastionPrimary]",
                 "subnetMaskForBastionPrimary": "[steps('connectivity').subnetMaskForBastionPrimary]",
+                "bastionPrimarySku": "[steps('connectivity').bastionPrimarySku]",
                 "enableBastionSecondary": "[steps('connectivity').esNetworkSecondarySubSection.enableBastionSecondary]",
                 "subnetMaskForBastionSecondary": "[steps('connectivity').esNetworkSecondarySubSection.subnetMaskForBastionSecondary]",
+                "bastionSecondarySku": "[steps('connectivity').esNetworkSecondarySubSection.bastionSecondarySku]",
                 "enableDnsResolverPrimary": "[steps('connectivity').enableDnsResolverPrimary]",
                 "subnetMaskForDnsResolverInboundPrimary": "[steps('connectivity').subnetMaskForDnsResolverInboundPrimary]",
                 "subnetMaskForDnsResolverOutboundPrimary": "[steps('connectivity').subnetMaskForDnsResolverOutboundPrimary]",

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -415,6 +415,15 @@
             "type": "string",
             "defaultValue": ""
         },
+        "bastionPrimarySku": {
+            "type": "string",
+            "defaultValue": "Premium",
+            "allowedValues": [
+                "Basic",
+                "Standard",
+                "Premium"
+            ]
+        },
         "enableBastionSecondary": {
             "type": "string",
             "defaultValue": "No",
@@ -426,6 +435,15 @@
         "subnetMaskForBastionSecondary": {
             "type": "string",
             "defaultValue": ""
+        },
+        "bastionSecondarySku": {
+            "type": "string",
+            "defaultValue": "Premium",
+            "allowedValues": [
+                "Basic",
+                "Standard",
+                "Premium"
+            ]
         },
         "enableDnsResolverPrimary": {
             "type": "string",
@@ -5406,6 +5424,9 @@
                     },
                     "resourceGroupOverride": {
                         "value": "[parameters('resourceNames').connectivityRg]"
+                    },
+                    "bastionSku": {
+                        "value": "[parameters('bastionPrimarySku')]"
                     }
                 }
             }
@@ -5839,6 +5860,9 @@
                     },
                     "resourceGroupOverride": {
                         "value": "[parameters('resourceNames').connectivityRg]"
+                    },
+                    "bastionSku": {
+                        "value": "[parameters('bastionPrimarySku')]"
                     }
                 }
             }
@@ -6016,7 +6040,10 @@
                         "value": "[parameters('connectivityLocationSecondary')]"
                     },
                     "resourceGroupOverride": {
-                        "value": "[parameters('resourceNames').connectivityRgSecondary]"
+                        "value": "[parameters('resourceNames').connectivityRg"
+                    },
+                    "bastionSku": {
+                        "value": "[parameters('bastionSecondarySku')]"
                     }
                 }
             }
@@ -6618,6 +6645,9 @@
                     },
                     "resourceGroupOverride": {
                         "value": "[parameters('resourceNames').connectivityRgSecondary]"
+                    },
+                    "bastionSku": {
+                        "value": "[parameters('bastionSecondarySku')]"
                     }
                 }
             }

--- a/eslzArm/managementGroupTemplates/policyAssignments/DINE-MDFCConfigPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DINE-MDFCConfigPolicyAssignment.json
@@ -127,15 +127,7 @@
                 "DeployIfNotExists"
             ],
             "defaultValue": "Disabled"
-        },
-        "exportResourceGroupName": {
-            "type": "string",
-            "metadata": {
-                "description": "Provide the name of the resource group where the Microsoft Defender for Cloud export will be deployed."
-            },
-            "defaultValue": "[concat('rg-mdfc-export-prod-', parameters('topLevelManagementGroupPrefix'))]"
         }
-
     },
     "variables": {
         "policyDefinitions": {
@@ -183,7 +175,7 @@
                         "value": "[parameters('logAnalyticsResourceId')]"
                     },
                     "ascExportResourceGroupName": {
-                        "value": "[parameters('exportResourceGroupName')]"
+                        "value": "[concat(parameters('topLevelManagementGroupPrefix'), '-asc-export')]"
                     },
                     "ascExportResourceGroupLocation": {
                         "value": "[deployment().location]"

--- a/eslzArm/managementGroupTemplates/policyAssignments/china/mcDINE-MDFCConfigPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/china/mcDINE-MDFCConfigPolicyAssignment.json
@@ -89,7 +89,7 @@
                         "value": "[parameters('logAnalyticsResourceId')]"
                     },
                     "ascExportResourceGroupName": {
-                        "value": "[concat('rg-', parameters('topLevelManagementGroupPrefix'), '-asc-export')]"
+                        "value": "[concat(parameters('topLevelManagementGroupPrefix'), '-asc-export')]"
                     },
                     "ascExportResourceGroupLocation": {
                         "value": "[deployment().location]"

--- a/eslzArm/managementGroupTemplates/policyAssignments/gov/fairfaxDINE-MDFCConfigPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/gov/fairfaxDINE-MDFCConfigPolicyAssignment.json
@@ -113,7 +113,7 @@
                         "value": "[parameters('logAnalyticsResourceId')]"
                     },
                     "ascExportResourceGroupName": {
-                        "value": "[concat('rg-', parameters('topLevelManagementGroupPrefix'), '-asc-export')]"
+                        "value": "[concat(parameters('topLevelManagementGroupPrefix'), '-asc-export')]"
                     },
                     "ascExportResourceGroupLocation": {
                         "value": "[deployment().location]"

--- a/eslzArm/subscriptionTemplates/bastion.json
+++ b/eslzArm/subscriptionTemplates/bastion.json
@@ -59,6 +59,19 @@
             "metadata": {
                 "description": "Name of the resource group to deploy to"
             }
+        },
+        "bastionSku": {
+            "type": "string",
+            "defaultValue": "Premium",
+            "allowedValues": [
+                "Basic",
+                "Developer",
+                "Standard",
+                "Premium"
+            ],
+            "metadata": {
+                "description": "The SKU of the Bastion Host to deploy"
+            }
         }
     },
     "variables": {
@@ -344,7 +357,7 @@
                             "name": "[parameters('bastionHostName')]",
                             "location": "[parameters('location')]",
                             "sku": {
-                                "name": "Premium"
+                                "name": "[parameters('bastionSku')]"
                             },
                             "zones": [
                                 "1",

--- a/eslzArm/subscriptionTemplates/bastion.json
+++ b/eslzArm/subscriptionTemplates/bastion.json
@@ -108,6 +108,9 @@
                     },
                     "bastionHostName": {
                         "value": "[parameters('bastionHostName')]"
+                    },
+                    "bastionSku": {
+                        "value": "[parameters('bastionSku')]"
                     }
                 },
                 "template": {
@@ -130,6 +133,9 @@
                             "type": "string"
                         },
                         "bastionHostName": {
+                            "type": "string"
+                        },
+                        "bastionSku": {
                             "type": "string"
                         }
                     },


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the Azure Landing Zones (ALZ) Portal Accelerator, focusing on improved Bastion deployment flexibility, documentation updates, and policy assignment corrections. The most significant changes are grouped below by theme.

**Bastion Deployment Enhancements:**

* Added support for selecting the Bastion Host SKU (Basic, Standard, Premium) for both primary and secondary deployments in the portal and ARM templates, ensuring users can choose the most appropriate SKU for their needs. This includes updates to `eslzArm/eslz-portal.json`, `eslzArm/eslzArm.json`, and `eslzArm/subscriptionTemplates/bastion.json`. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR3821-R3848) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR5244-R5271) [[3]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR10992-R10995) [[4]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R418-R426) [[5]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R439-R447) [[6]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R5427-R5429) [[7]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R5863-R5865) [[8]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L6019-R6046) [[9]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R6648-R6650) [[10]](diffhunk://#diff-d969684369584c74f37672bc908554082a75100623d36ade0259aaf5ef1bd68bR62-R74) [[11]](diffhunk://#diff-d969684369584c74f37672bc908554082a75100623d36ade0259aaf5ef1bd68bR111-R113) [[12]](diffhunk://#diff-d969684369584c74f37672bc908554082a75100623d36ade0259aaf5ef1bd68bR137-R139) [[13]](diffhunk://#diff-d969684369584c74f37672bc908554082a75100623d36ade0259aaf5ef1bd68bL347-R366)
* Updated Bastion deployment tooltip and default behavior to clarify that only zone-redundant Bastion is deployed, and improved documentation links in the portal.

**Documentation Updates:**

* Added a new "December 2025" section to the "What's New" documentation, highlighting the new Bastion and Private DNS Resolver support, and clarified the last mile configuration required for Private DNS Resolver. Also, removed duplicated or outdated October 2025 entries to keep the changelog clean and accurate. [[1]](diffhunk://#diff-dc6403d6507d3ee6a1e907f047aa79fc3a0733256a2fdf5507a64ac754e7ff61R4) [[2]](diffhunk://#diff-dc6403d6507d3ee6a1e907f047aa79fc3a0733256a2fdf5507a64ac754e7ff61L64-R75) [[3]](diffhunk://#diff-dc6403d6507d3ee6a1e907f047aa79fc3a0733256a2fdf5507a64ac754e7ff61L80-L88) [[4]](diffhunk://#diff-dc6403d6507d3ee6a1e907f047aa79fc3a0733256a2fdf5507a64ac754e7ff61L151-L154)

**Policy Assignment Fixes:**

* Fixed the naming logic for the Microsoft Defender for Cloud export resource group in policy assignment templates, ensuring consistent and correct resource group names across global, China, and government environments. [[1]](diffhunk://#diff-674e885ca90b87d3e763d5a15c532f4a4dc3c914878729c3dc037c3e760a9de1L130-L138) [[2]](diffhunk://#diff-674e885ca90b87d3e763d5a15c532f4a4dc3c914878729c3dc037c3e760a9de1L186-R178) [[3]](diffhunk://#diff-122420b50c35f5665196774235268681bd7d83ecea25a90ecaf05d82de1e40f1L92-R92) [[4]](diffhunk://#diff-01ec642da8aedb338007edd6698eaa09549e1a5b2d0d4964a8aa37864eaeb231L116-R116)