### PR TITLE
Updating release

### DIFF
--- a/src/portal/release.json
+++ b/src/portal/release.json
@@ -1,6 +1,6 @@
 {
-    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2025-09-17",
-    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-09-17/eslzArm/eslzArm.json",
-    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/2025-09-17/eslzArm/eslzArm.json",
-    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2025-09-17/eslzArm/eslz-portal.json"
+    "azureLandingZoneTemplateDetailsUri": "https://github.com/Azure/Enterprise-Scale/tree/2026-01-21",
+    "templateUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2026-01-21/eslzArm/eslzArm.json",
+    "templateUriBlob": "https://github.com/Azure/Enterprise-Scale/blob/2026-01-21/eslzArm/eslzArm.json",
+    "uiFormDefinitionUri": "https://raw.githubusercontent.com/Azure/Enterprise-Scale/2026-01-21/eslzArm/eslz-portal.json"
 }


### PR DESCRIPTION
This pull request updates the version references for Azure Enterprise-Scale templates in the `release.json` file. The URIs now point to the `2026-01-21` release instead of the previous `2025-09-17` version. This ensures that the portal uses the latest templates and definitions.

- Updated all template and form definition URIs in `src/portal/release.json` to reference the `2026-01-21` release of Azure Enterprise-Scale, ensuring the latest resources are used.