### PR TITLE
fix: Change deny value to Deny in policy assignment

### DIFF
--- a/eslzArm/managementGroupTemplates/policyAssignments/DENY-AksPrivilegedPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DENY-AksPrivilegedPolicyAssignment.json
@@ -35,7 +35,7 @@
                 "enforcementMode": "[parameters('enforcementMode')]",
                 "parameters": {
                     "effect": {
-                        "value": "deny"
+                        "value": "Deny"
                     }
                 }
             }


### PR DESCRIPTION
This pull request makes a minor change to the `DENY-AksPrivilegedPolicyAssignment.json` policy assignment template, standardizing the capitalization of the policy effect value.

* Changed the `effect` parameter value from `"deny"` to `"Deny"` to ensure consistent capitalization in policy assignment configuration.

This is because the built-in parameter has allowed values which forces case sensitivity https://www.azadvertizer.net/azpolicyadvertizer/1c6e92c9-99f0-4e55-9cf2-0c234dc48f99.html