### PR TITLE
fix: Update deny value to Deny in policy assignment files after checking defs

### DIFF
--- a/eslzArm/managementGroupTemplates/policyAssignments/DENY-AksPrivEscalationPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DENY-AksPrivEscalationPolicyAssignment.json
@@ -35,7 +35,7 @@
                 "enforcementMode": "[parameters('enforcementMode')]",
                 "parameters": {
                     "effect": {
-                        "value": "deny"
+                        "value": "Deny"
                     }
                 }
             }

--- a/eslzArm/managementGroupTemplates/policyAssignments/DENY-AksWithoutHttpsPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/DENY-AksWithoutHttpsPolicyAssignment.json
@@ -35,7 +35,7 @@
                 "enforcementMode": "[parameters('enforcementMode')]",
                 "parameters": {
                     "effect": {
-                        "value": "deny"
+                        "value": "Deny"
                     }
                 }
             }


### PR DESCRIPTION
This pull request makes a minor update to the policy assignment templates by standardizing the casing of the `effect` parameter value from "deny" to "Deny" in two files. This ensures compatibility with the allowed values in the definitions.

- Standardized the `effect` parameter value to "Deny" in the following policy assignment templates:
  - `DENY-AksPrivEscalationPolicyAssignment.json`
  - `DENY-AksWithoutHttpsPolicyAssignment.json`

This is so they match the `allowedValues` in their underlying definitions