### PR TITLE
Update policy definition 'Deny-Subnet-Without-Udr' to include default value 'RouteServerSubnet' in parameter 'excludedSubnets'

### DIFF
--- a/docs/wiki/Whats-new.md
+++ b/docs/wiki/Whats-new.md
@@ -81,6 +81,10 @@ Here's what's changed in Enterprise Scale/Azure Landing Zones:
 
 - Updated Portal Accelerator to remove all HTML used to enhance the layout and experience. We've had to remove all HTML as the use of HTML in templates will now be blocked for security reasons.
 
+#### Policy
+
+- Updated the definition [Deny-Subnet-Without-Udr](https://www.azadvertizer.net/azpolicyadvertizer/Deny-Subnet-Without-Udr.html) to add default value 'RouteServerSubnet' to parameter 'excludedSubnets'.
+
 ### December 2025
 
 #### Tooling

--- a/src/resources/Microsoft.Authorization/policyDefinitions/Deny-Subnet-Without-Udr.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/Deny-Subnet-Without-Udr.json
@@ -39,7 +39,8 @@
           "description": "Array of subnet names that are excluded from this policy"
         },
         "defaultValue": [
-          "AzureBastionSubnet"
+          "AzureBastionSubnet",
+          "RouteServerSubnet"
         ]
       }
     },


### PR DESCRIPTION
## Overview/Summary


## This PR fixes/adds/changes/removes

1.  Add default value 'RouteServerSubnet' to parameter 'excludedSubnets' in policy definition 'Deny-Subnet-Without-Udr',

### Breaking Changes

1. None

## Testing Evidence

1. Small change to default values:
<img width="1189" height="764" alt="deny-subnet-without-udr-pr" src="https://github.com/user-attachments/assets/c5c943a3-13ae-4ebb-a801-da4c6014c8ae" />

## As part of this Pull Request I have

- [X ] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [X] Performed testing and provided evidence.
- [X] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [X] Updated relevant and associated documentation.
- [X] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
