### PR TITLE
fix: adding missing spc and itn regions to pdns resolver template

### DIFF
--- a/eslzArm/subscriptionTemplates/privateDnsResolver.json
+++ b/eslzArm/subscriptionTemplates/privateDnsResolver.json
@@ -1,637 +1,624 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "resolverVnetName": {
-            "type": "string",
-            "defaultValue": "vnet01",
-            "metadata": {
-                "description": "Name of new or existing vnet to which Azure Bastion should be deployed"
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().location]",
-            "allowedValues": [
-                "australiaeast",
-                "uksouth",
-                "northeurope",
-                "southcentralus",
-                "westus3",
-                "eastus",
-                "northcentralus",
-                "westcentralus",
-                "eastus2",
-                "westeurope",
-                "centralus",
-                "canadacentral",
-                "brazilsouth",
-                "francecentral",
-                "swedencentral",
-                "switzerlandnorth",
-                "eastasia",
-                "southeastasia",
-                "japaneast",
-                "koreacentral",
-                "southafricanorth",
-                "centralindia",
-                "westus",
-                "canadaeast",
-                "qatarcentral",
-                "uaenorth",
-                "australiasoutheast",
-                "polandcentral"
-            ],
-            "metadata": {
-                "description": "Azure region for DNS private resolver and virtual network. Azure DNS Private Resolver available in specific region, refer the documentation to select the supported region for this deployment. For more information https://docs.microsoft.com/azure/dns/dns-private-resolver-overview#regional-availability"
-            }
-        },
-        "inboundSubnet": {
-            "type": "string",
-            "defaultValue": "snet-dnspr-in",
-            "metadata": {
-                "description": "Name of the subnet that will be used for private resolver inbound endpoint"
-            }
-        },
-        "inboundAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.100.9.0/28",
-            "metadata": {
-                "description": "The inbound endpoint subnet address space"
-            }
-        },
-        "outboundSubnet": {
-            "type": "string",
-            "defaultValue": "snet-dnspr-out",
-            "metadata": {
-                "description": "Name of the subnet that will be used for private resolver outbound endpoint"
-            }
-        },
-        "outboundAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.100.9.16/28",
-            "metadata": {
-                "description": "The outbound endpoint subnet address space"
-            }
-        },
-        "resolvervnetlink": {
-            "type": "string",
-            "defaultValue": "dnspr-vnetlink",
-            "metadata": {
-                "description": "Name of the vnet link that links outbound endpoint with forwarding rule set"
-            }
-        },
-        "forwardingRulesetName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the forwarding ruleset"
-            }
-        },
-        "topLevelManagementGroupPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the intermediate root management group"
-            }
-        },
-        "resourceGroupOverride": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the resource group to deploy to"
-            }
-        },
-        "vnetRg": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the resource group where the vnet is located"
-            }
-        },
-        "dnsResolverName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name for the DNS resolver"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resolverVnetName": {
+      "type": "string",
+      "defaultValue": "vnet01",
+      "metadata": {
+        "description": "Name of new or existing vnet to which Azure Bastion should be deployed"
+      }
     },
-    "variables": {
-        "resourceDeploymentName": "[format('dsnpr-{0}-deployment', parameters('location'))]",
-        "rgName": "[if(empty(parameters('resourceGroupOverride')), format('rg-{0}-dnspr-{1}', parameters('topLevelManagementGroupPrefix'), parameters('location')), parameters('resourceGroupOverride'))]",
-        "dnsForwardingRuleName": "[if(empty(parameters('forwardingRulesetName')), concat('dnsfrs-', parameters('topLevelManagementGroupPrefix'), '-', parameters('location')), parameters('forwardingRulesetName'))]"
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "allowedValues": [
+        "australiaeast",
+        "uksouth",
+        "northeurope",
+        "southcentralus",
+        "westus3",
+        "eastus",
+        "northcentralus",
+        "westcentralus",
+        "eastus2",
+        "westeurope",
+        "centralus",
+        "canadacentral",
+        "brazilsouth",
+        "francecentral",
+        "swedencentral",
+        "switzerlandnorth",
+        "eastasia",
+        "southeastasia",
+        "japaneast",
+        "koreacentral",
+        "southafricanorth",
+        "centralindia",
+        "westus",
+        "canadaeast",
+        "qatarcentral",
+        "uaenorth",
+        "australiasoutheast",
+        "polandcentral",
+        "spaincentral",
+        "italynorth"
+      ],
+      "metadata": {
+        "description": "Azure region for DNS private resolver and virtual network. Azure DNS Private Resolver available in specific region, refer the documentation to select the supported region for this deployment. For more information https://docs.microsoft.com/azure/dns/dns-private-resolver-overview#regional-availability"
+      }
     },
-    "resources": [
-        {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2019-10-01",
-            "name": "[concat(variables('resourceDeploymentName'), '-corenetworking')]",
-            "resourceGroup": "[parameters('vnetRg')]",
-            "dependsOn": [
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "location": {
-                        "value": "[parameters('location')]"
-                    },
-                    "resolverVnetName": {
-                        "value": "[parameters('resolverVnetName')]"
-                    },
-                    "dnsResolverName": {
-                        "value": "[parameters('dnsResolverName')]"
-                    },
-                    "inboundAddressPrefix": {
-                        "value": "[parameters('inboundAddressPrefix')]"
-                    },
-                    "inboundSubnet": {
-                        "value": "[parameters('inboundSubnet')]"
-                    },
-                    "outboundAddressPrefix": {
-                        "value": "[parameters('outboundAddressPrefix')]"
-                    },
-                    "outboundSubnet": {
-                        "value": "[parameters('outboundSubnet')]"
-                    }
-                },
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "location": {
-                            "type": "string"
-                        },
-                        "resolverVnetName": {
-                            "type": "string"
-                        },
-                        "dnsResolverName": {
-                            "type": "string"
-                        },
-                        "inboundAddressPrefix": {
-                            "type": "string"
-                        },
-                        "inboundSubnet": {
-                            "type": "string"
-                        },
-                        "outboundAddressPrefix": {
-                            "type": "string"
-                        },
-                        "outboundSubnet": {
-                            "type": "string"
-                        }
-                    },
-                    "variables": {
-                        "nsgNameInbound": "[format('{0}-inbound-nsg', parameters('dnsResolverName'))]",
-                        "nsgNameOutbound": "[format('{0}-outbound-nsg', parameters('dnsResolverName'))]"
-                    },
-                    "resources": [
-                        {
-                            "type": "Microsoft.Network/networkSecurityGroups",
-                            "apiVersion": "2022-07-01",
-                            "name": "[variables('nsgNameInbound')]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "securityRules": [
-                                    {
-                                        "name": "AllowHttpsInBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "Internet",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Allow",
-                                            "priority": 100,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowGatewayManagerInBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "GatewayManager",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Allow",
-                                            "priority": 110,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowLoadBalancerInBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "AzureLoadBalancer",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Allow",
-                                            "priority": 120,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "DenyAllInBound",
-                                        "properties": {
-                                            "protocol": "*",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationPortRange": "*",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Deny",
-                                            "priority": 1000,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowSshRdpOutBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationPortRanges": [
-                                                "22",
-                                                "3389"
-                                            ],
-                                            "destinationAddressPrefix": "VirtualNetwork",
-                                            "access": "Allow",
-                                            "priority": 100,
-                                            "direction": "Outbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowAzureCloudCommunicationOutBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "AzureCloud",
-                                            "access": "Allow",
-                                            "priority": 110,
-                                            "direction": "Outbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowGetSessionInformationOutBound",
-                                        "properties": {
-                                            "protocol": "*",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationAddressPrefix": "Internet",
-                                            "destinationPortRanges": [
-                                                "80",
-                                                "443"
-                                            ],
-                                            "access": "Allow",
-                                            "priority": 130,
-                                            "direction": "Outbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "DenyAllOutBound",
-                                        "properties": {
-                                            "protocol": "*",
-                                            "sourcePortRange": "*",
-                                            "destinationPortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Deny",
-                                            "priority": 1000,
-                                            "direction": "Outbound"
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "type": "Microsoft.Network/networkSecurityGroups",
-                            "apiVersion": "2022-07-01",
-                            "name": "[variables('nsgNameOutbound')]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "securityRules": [
-                                    {
-                                        "name": "AllowHttpsInBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "Internet",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Allow",
-                                            "priority": 100,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowGatewayManagerInBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "GatewayManager",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Allow",
-                                            "priority": 110,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowLoadBalancerInBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "AzureLoadBalancer",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Allow",
-                                            "priority": 120,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "DenyAllInBound",
-                                        "properties": {
-                                            "protocol": "*",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationPortRange": "*",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Deny",
-                                            "priority": 1000,
-                                            "direction": "Inbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowSshRdpOutBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationPortRanges": [
-                                                "22",
-                                                "3389"
-                                            ],
-                                            "destinationAddressPrefix": "VirtualNetwork",
-                                            "access": "Allow",
-                                            "priority": 100,
-                                            "direction": "Outbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowAzureCloudCommunicationOutBound",
-                                        "properties": {
-                                            "protocol": "Tcp",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationPortRange": "443",
-                                            "destinationAddressPrefix": "AzureCloud",
-                                            "access": "Allow",
-                                            "priority": 110,
-                                            "direction": "Outbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "AllowGetSessionInformationOutBound",
-                                        "properties": {
-                                            "protocol": "*",
-                                            "sourcePortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationAddressPrefix": "Internet",
-                                            "destinationPortRanges": [
-                                                "80",
-                                                "443"
-                                            ],
-                                            "access": "Allow",
-                                            "priority": 130,
-                                            "direction": "Outbound"
-                                        }
-                                    },
-                                    {
-                                        "name": "DenyAllOutBound",
-                                        "properties": {
-                                            "protocol": "*",
-                                            "sourcePortRange": "*",
-                                            "destinationPortRange": "*",
-                                            "sourceAddressPrefix": "*",
-                                            "destinationAddressPrefix": "*",
-                                            "access": "Deny",
-                                            "priority": 1000,
-                                            "direction": "Outbound"
-                                        }
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "type": "Microsoft.Network/virtualNetworks/subnets",
-                            "apiVersion": "2022-07-01",
-                            "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('inboundSubnet'))]",
-                            "properties": {
-                                "addressPrefix": "[parameters('inboundAddressPrefix')]",
-                                "networkSecurityGroup": {
-                                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
-                                },
-                                "delegations": [
-                                    {
-                                        "name": "Microsoft.Network.dnsResolvers",
-                                        "properties": {
-                                            "serviceName": "Microsoft.Network/dnsResolvers"
-                                        }
-                                    }
-                                ]
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
-                            ]
-                        },
-                        {
-                            "type": "Microsoft.Network/virtualNetworks/subnets",
-                            "apiVersion": "2022-07-01",
-                            "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('outboundSubnet'))]",
-                            "properties": {
-                                "addressPrefix": "[parameters('outboundAddressPrefix')]",
-                                "networkSecurityGroup": {
-                                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]"
-                                },
-                                "delegations": [
-                                    {
-                                        "name": "Microsoft.Network.dnsResolvers",
-                                        "properties": {
-                                            "serviceName": "Microsoft.Network/dnsResolvers"
-                                        }
-                                    }
-                                ]
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]",
-                                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('resolverVnetName'), parameters('inboundSubnet'))]"
-                            ]
-                        }
-                    ]
-                }
-            }
+    "inboundSubnet": {
+      "type": "string",
+      "defaultValue": "snet-dnspr-in",
+      "metadata": {
+        "description": "Name of the subnet that will be used for private resolver inbound endpoint"
+      }
+    },
+    "inboundAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.100.9.0/28",
+      "metadata": {
+        "description": "The inbound endpoint subnet address space"
+      }
+    },
+    "outboundSubnet": {
+      "type": "string",
+      "defaultValue": "snet-dnspr-out",
+      "metadata": {
+        "description": "Name of the subnet that will be used for private resolver outbound endpoint"
+      }
+    },
+    "outboundAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.100.9.16/28",
+      "metadata": {
+        "description": "The outbound endpoint subnet address space"
+      }
+    },
+    "resolvervnetlink": {
+      "type": "string",
+      "defaultValue": "dnspr-vnetlink",
+      "metadata": {
+        "description": "Name of the vnet link that links outbound endpoint with forwarding rule set"
+      }
+    },
+    "forwardingRulesetName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the forwarding ruleset"
+      }
+    },
+    "topLevelManagementGroupPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the intermediate root management group"
+      }
+    },
+    "resourceGroupOverride": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the resource group to deploy to"
+      }
+    },
+    "vnetRg": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the resource group where the vnet is located"
+      }
+    },
+    "dnsResolverName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for the DNS resolver"
+      }
+    }
+  },
+  "variables": {
+    "resourceDeploymentName": "[format('dsnpr-{0}-deployment', parameters('location'))]",
+    "rgName": "[if(empty(parameters('resourceGroupOverride')), format('rg-{0}-dnspr-{1}', parameters('topLevelManagementGroupPrefix'), parameters('location')), parameters('resourceGroupOverride'))]",
+    "dnsForwardingRuleName": "[if(empty(parameters('forwardingRulesetName')), concat('dnsfrs-', parameters('topLevelManagementGroupPrefix'), '-', parameters('location')), parameters('forwardingRulesetName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[concat(variables('resourceDeploymentName'), '-corenetworking')]",
+      "resourceGroup": "[parameters('vnetRg')]",
+      "dependsOn": [],
+      "properties": {
+        "mode": "Incremental",
+        "expressionEvaluationOptions": {
+          "scope": "inner"
         },
-        {
-            "type": "Microsoft.Resources/resourceGroups",
-            "apiVersion": "2020-10-01",
-            "name": "[variables('rgName')]",
-            "location": "[parameters('location')]"
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "resolverVnetName": {
+            "value": "[parameters('resolverVnetName')]"
+          },
+          "dnsResolverName": {
+            "value": "[parameters('dnsResolverName')]"
+          },
+          "inboundAddressPrefix": {
+            "value": "[parameters('inboundAddressPrefix')]"
+          },
+          "inboundSubnet": {
+            "value": "[parameters('inboundSubnet')]"
+          },
+          "outboundAddressPrefix": {
+            "value": "[parameters('outboundAddressPrefix')]"
+          },
+          "outboundSubnet": {
+            "value": "[parameters('outboundSubnet')]"
+          }
         },
-        {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2019-10-01",
-            "name": "[variables('resourceDeploymentName')]",
-            "resourceGroup": "[variables('rgName')]",
-            "dependsOn": [
-                "[concat('Microsoft.Resources/resourceGroups/', variables('rgName'))]",
-                "[concat(variables('resourceDeploymentName'), '-corenetworking')]"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "location": {
-                        "value": "[parameters('location')]"
-                    },
-                    "resolverVnetName": {
-                        "value": "[parameters('resolverVnetName')]"
-                    },
-                    "vnetRgName": {
-                        "value": "[parameters('vnetRg')]"
-                    },
-                    "dnsResolverName": {
-                        "value": "[parameters('dnsResolverName')]"
-                    },
-                    "inboundSubnet": {
-                        "value": "[parameters('inboundSubnet')]"
-                    },
-                    "outboundSubnet": {
-                        "value": "[parameters('outboundSubnet')]"
-                    },
-                    "forwardingRulesetName": {
-                        "value": "[variables('dnsForwardingRuleName')]"
-                    },
-                    "resolvervnetlink": {
-                        "value": "[parameters('resolvervnetlink')]"
-                    }
-                },
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "location": {
-                            "type": "string"
-                        },
-                        "resolverVnetName": {
-                            "type": "string"
-                        },
-                        "vnetRgName": {
-                            "type": "string"
-                        },
-                        "dnsResolverName": {
-                            "type": "string"
-                        },
-                        "inboundSubnet": {
-                            "type": "string"
-                        },
-                        "outboundSubnet": {
-                            "type": "string"
-                        },
-                        "forwardingRulesetName": {
-                            "type": "string"
-                        },
-                        "resolvervnetlink": {
-                            "type": "string"
-                        }
-                    },
-                    "variables": {
-                    },
-                    "resources": [
-                        {
-                            "type": "Microsoft.Network/dnsResolvers",
-                            "apiVersion": "2022-07-01",
-                            "name": "[parameters('dnsResolverName')]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "virtualNetwork": {
-                                    "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
-                                }
-                            },
-                            "dependsOn": [
-                            ]
-                        },
-                        {
-                        "type": "Microsoft.Network/dnsResolvers/inboundEndpoints",
-                        "apiVersion": "2022-07-01",
-                        "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('inboundSubnet'))]",
-                        "location": "[parameters('location')]",
-                        "properties": {
-                            "ipConfigurations": [
-                            {
-                                "privateIpAllocationMethod": "Dynamic",
-                                "subnet": {
-                                    "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('inboundSubnet'))]"
-                                }
-                            }
-                            ]
-                        },
-                        "dependsOn": [
-                            "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
-                        ]
-                        },
-                        {
-                            "type": "Microsoft.Network/dnsResolvers/outboundEndpoints",
-                            "apiVersion": "2022-07-01",
-                            "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('outboundSubnet'))]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "subnet": {
-                                    "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('outboundSubnet'))]"
-                                }
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
-                            ]
-                        },
-                        {
-                            "type": "Microsoft.Network/dnsForwardingRulesets",
-                            "apiVersion": "2022-07-01",
-                            "name": "[parameters('forwardingRulesetName')]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "dnsResolverOutboundEndpoints": [
-                                    {
-                                        "id": "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
-                                    }
-                                ]
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
-                            ]
-                        },
-                        {
-                            "type": "Microsoft.Network/dnsForwardingRulesets/virtualNetworkLinks",
-                            "apiVersion": "2022-07-01",
-                            "name": "[format('{0}/{1}', parameters('forwardingRulesetName'), parameters('resolvervnetlink'))]",
-                            "properties": {
-                                "virtualNetwork": {
-                                    "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
-                                }
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Network/dnsForwardingRulesets', parameters('forwardingRulesetName'))]"
-                            ]
-                        }
-                    ]
-                }
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string"
+            },
+            "resolverVnetName": {
+              "type": "string"
+            },
+            "dnsResolverName": {
+              "type": "string"
+            },
+            "inboundAddressPrefix": {
+              "type": "string"
+            },
+            "inboundSubnet": {
+              "type": "string"
+            },
+            "outboundAddressPrefix": {
+              "type": "string"
+            },
+            "outboundSubnet": {
+              "type": "string"
             }
+          },
+          "variables": {
+            "nsgNameInbound": "[format('{0}-inbound-nsg', parameters('dnsResolverName'))]",
+            "nsgNameOutbound": "[format('{0}-outbound-nsg', parameters('dnsResolverName'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2022-07-01",
+              "name": "[variables('nsgNameInbound')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "AllowHttpsInBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "Internet",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 100,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowGatewayManagerInBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "GatewayManager",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 110,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowLoadBalancerInBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "AzureLoadBalancer",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 120,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "DenyAllInBound",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": 1000,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowSshRdpOutBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRanges": ["22", "3389"],
+                      "destinationAddressPrefix": "VirtualNetwork",
+                      "access": "Allow",
+                      "priority": 100,
+                      "direction": "Outbound"
+                    }
+                  },
+                  {
+                    "name": "AllowAzureCloudCommunicationOutBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "AzureCloud",
+                      "access": "Allow",
+                      "priority": 110,
+                      "direction": "Outbound"
+                    }
+                  },
+                  {
+                    "name": "AllowGetSessionInformationOutBound",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "Internet",
+                      "destinationPortRanges": ["80", "443"],
+                      "access": "Allow",
+                      "priority": 130,
+                      "direction": "Outbound"
+                    }
+                  },
+                  {
+                    "name": "DenyAllOutBound",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": 1000,
+                      "direction": "Outbound"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2022-07-01",
+              "name": "[variables('nsgNameOutbound')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "AllowHttpsInBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "Internet",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 100,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowGatewayManagerInBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "GatewayManager",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 110,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowLoadBalancerInBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "AzureLoadBalancer",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 120,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "DenyAllInBound",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": 1000,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowSshRdpOutBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRanges": ["22", "3389"],
+                      "destinationAddressPrefix": "VirtualNetwork",
+                      "access": "Allow",
+                      "priority": 100,
+                      "direction": "Outbound"
+                    }
+                  },
+                  {
+                    "name": "AllowAzureCloudCommunicationOutBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "AzureCloud",
+                      "access": "Allow",
+                      "priority": 110,
+                      "direction": "Outbound"
+                    }
+                  },
+                  {
+                    "name": "AllowGetSessionInformationOutBound",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "Internet",
+                      "destinationPortRanges": ["80", "443"],
+                      "access": "Allow",
+                      "priority": 130,
+                      "direction": "Outbound"
+                    }
+                  },
+                  {
+                    "name": "DenyAllOutBound",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": 1000,
+                      "direction": "Outbound"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Network/virtualNetworks/subnets",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('inboundSubnet'))]",
+              "properties": {
+                "addressPrefix": "[parameters('inboundAddressPrefix')]",
+                "networkSecurityGroup": {
+                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
+                },
+                "delegations": [
+                  {
+                    "name": "Microsoft.Network.dnsResolvers",
+                    "properties": {
+                      "serviceName": "Microsoft.Network/dnsResolvers"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/virtualNetworks/subnets",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('outboundSubnet'))]",
+              "properties": {
+                "addressPrefix": "[parameters('outboundAddressPrefix')]",
+                "networkSecurityGroup": {
+                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]"
+                },
+                "delegations": [
+                  {
+                    "name": "Microsoft.Network.dnsResolvers",
+                    "properties": {
+                      "serviceName": "Microsoft.Network/dnsResolvers"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('resolverVnetName'), parameters('inboundSubnet'))]"
+              ]
+            }
+          ]
         }
-    ]
+      }
+    },
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2020-10-01",
+      "name": "[variables('rgName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[variables('resourceDeploymentName')]",
+      "resourceGroup": "[variables('rgName')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/resourceGroups/', variables('rgName'))]",
+        "[concat(variables('resourceDeploymentName'), '-corenetworking')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "resolverVnetName": {
+            "value": "[parameters('resolverVnetName')]"
+          },
+          "vnetRgName": {
+            "value": "[parameters('vnetRg')]"
+          },
+          "dnsResolverName": {
+            "value": "[parameters('dnsResolverName')]"
+          },
+          "inboundSubnet": {
+            "value": "[parameters('inboundSubnet')]"
+          },
+          "outboundSubnet": {
+            "value": "[parameters('outboundSubnet')]"
+          },
+          "forwardingRulesetName": {
+            "value": "[variables('dnsForwardingRuleName')]"
+          },
+          "resolvervnetlink": {
+            "value": "[parameters('resolvervnetlink')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": {
+              "type": "string"
+            },
+            "resolverVnetName": {
+              "type": "string"
+            },
+            "vnetRgName": {
+              "type": "string"
+            },
+            "dnsResolverName": {
+              "type": "string"
+            },
+            "inboundSubnet": {
+              "type": "string"
+            },
+            "outboundSubnet": {
+              "type": "string"
+            },
+            "forwardingRulesetName": {
+              "type": "string"
+            },
+            "resolvervnetlink": {
+              "type": "string"
+            }
+          },
+          "variables": {},
+          "resources": [
+            {
+              "type": "Microsoft.Network/dnsResolvers",
+              "apiVersion": "2022-07-01",
+              "name": "[parameters('dnsResolverName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "virtualNetwork": {
+                  "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
+                }
+              },
+              "dependsOn": []
+            },
+            {
+              "type": "Microsoft.Network/dnsResolvers/inboundEndpoints",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('inboundSubnet'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "privateIpAllocationMethod": "Dynamic",
+                    "subnet": {
+                      "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('inboundSubnet'))]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/dnsResolvers/outboundEndpoints",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('outboundSubnet'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "subnet": {
+                  "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('outboundSubnet'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/dnsForwardingRulesets",
+              "apiVersion": "2022-07-01",
+              "name": "[parameters('forwardingRulesetName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "dnsResolverOutboundEndpoints": [
+                  {
+                    "id": "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/dnsForwardingRulesets/virtualNetworkLinks",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('forwardingRulesetName'), parameters('resolvervnetlink'))]",
+              "properties": {
+                "virtualNetwork": {
+                  "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/dnsForwardingRulesets', parameters('forwardingRulesetName'))]"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/eslzArm/subscriptionTemplates/privateDnsResolver.json
+++ b/eslzArm/subscriptionTemplates/privateDnsResolver.json
@@ -1,624 +1,639 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "resolverVnetName": {
-      "type": "string",
-      "defaultValue": "vnet01",
-      "metadata": {
-        "description": "Name of new or existing vnet to which Azure Bastion should be deployed"
-      }
-    },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]",
-      "allowedValues": [
-        "australiaeast",
-        "uksouth",
-        "northeurope",
-        "southcentralus",
-        "westus3",
-        "eastus",
-        "northcentralus",
-        "westcentralus",
-        "eastus2",
-        "westeurope",
-        "centralus",
-        "canadacentral",
-        "brazilsouth",
-        "francecentral",
-        "swedencentral",
-        "switzerlandnorth",
-        "eastasia",
-        "southeastasia",
-        "japaneast",
-        "koreacentral",
-        "southafricanorth",
-        "centralindia",
-        "westus",
-        "canadaeast",
-        "qatarcentral",
-        "uaenorth",
-        "australiasoutheast",
-        "polandcentral",
-        "spaincentral",
-        "italynorth"
-      ],
-      "metadata": {
-        "description": "Azure region for DNS private resolver and virtual network. Azure DNS Private Resolver available in specific region, refer the documentation to select the supported region for this deployment. For more information https://docs.microsoft.com/azure/dns/dns-private-resolver-overview#regional-availability"
-      }
-    },
-    "inboundSubnet": {
-      "type": "string",
-      "defaultValue": "snet-dnspr-in",
-      "metadata": {
-        "description": "Name of the subnet that will be used for private resolver inbound endpoint"
-      }
-    },
-    "inboundAddressPrefix": {
-      "type": "string",
-      "defaultValue": "10.100.9.0/28",
-      "metadata": {
-        "description": "The inbound endpoint subnet address space"
-      }
-    },
-    "outboundSubnet": {
-      "type": "string",
-      "defaultValue": "snet-dnspr-out",
-      "metadata": {
-        "description": "Name of the subnet that will be used for private resolver outbound endpoint"
-      }
-    },
-    "outboundAddressPrefix": {
-      "type": "string",
-      "defaultValue": "10.100.9.16/28",
-      "metadata": {
-        "description": "The outbound endpoint subnet address space"
-      }
-    },
-    "resolvervnetlink": {
-      "type": "string",
-      "defaultValue": "dnspr-vnetlink",
-      "metadata": {
-        "description": "Name of the vnet link that links outbound endpoint with forwarding rule set"
-      }
-    },
-    "forwardingRulesetName": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Name of the forwarding ruleset"
-      }
-    },
-    "topLevelManagementGroupPrefix": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the intermediate root management group"
-      }
-    },
-    "resourceGroupOverride": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Name of the resource group to deploy to"
-      }
-    },
-    "vnetRg": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Name of the resource group where the vnet is located"
-      }
-    },
-    "dnsResolverName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name for the DNS resolver"
-      }
-    }
-  },
-  "variables": {
-    "resourceDeploymentName": "[format('dsnpr-{0}-deployment', parameters('location'))]",
-    "rgName": "[if(empty(parameters('resourceGroupOverride')), format('rg-{0}-dnspr-{1}', parameters('topLevelManagementGroupPrefix'), parameters('location')), parameters('resourceGroupOverride'))]",
-    "dnsForwardingRuleName": "[if(empty(parameters('forwardingRulesetName')), concat('dnsfrs-', parameters('topLevelManagementGroupPrefix'), '-', parameters('location')), parameters('forwardingRulesetName'))]"
-  },
-  "resources": [
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2019-10-01",
-      "name": "[concat(variables('resourceDeploymentName'), '-corenetworking')]",
-      "resourceGroup": "[parameters('vnetRg')]",
-      "dependsOn": [],
-      "properties": {
-        "mode": "Incremental",
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "parameters": {
-          "location": {
-            "value": "[parameters('location')]"
-          },
-          "resolverVnetName": {
-            "value": "[parameters('resolverVnetName')]"
-          },
-          "dnsResolverName": {
-            "value": "[parameters('dnsResolverName')]"
-          },
-          "inboundAddressPrefix": {
-            "value": "[parameters('inboundAddressPrefix')]"
-          },
-          "inboundSubnet": {
-            "value": "[parameters('inboundSubnet')]"
-          },
-          "outboundAddressPrefix": {
-            "value": "[parameters('outboundAddressPrefix')]"
-          },
-          "outboundSubnet": {
-            "value": "[parameters('outboundSubnet')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string"
-            },
-            "resolverVnetName": {
-              "type": "string"
-            },
-            "dnsResolverName": {
-              "type": "string"
-            },
-            "inboundAddressPrefix": {
-              "type": "string"
-            },
-            "inboundSubnet": {
-              "type": "string"
-            },
-            "outboundAddressPrefix": {
-              "type": "string"
-            },
-            "outboundSubnet": {
-              "type": "string"
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resolverVnetName": {
+            "type": "string",
+            "defaultValue": "vnet01",
+            "metadata": {
+                "description": "Name of new or existing vnet to which Azure Bastion should be deployed"
             }
-          },
-          "variables": {
-            "nsgNameInbound": "[format('{0}-inbound-nsg', parameters('dnsResolverName'))]",
-            "nsgNameOutbound": "[format('{0}-outbound-nsg', parameters('dnsResolverName'))]"
-          },
-          "resources": [
-            {
-              "type": "Microsoft.Network/networkSecurityGroups",
-              "apiVersion": "2022-07-01",
-              "name": "[variables('nsgNameInbound')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "securityRules": [
-                  {
-                    "name": "AllowHttpsInBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "Internet",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "*",
-                      "access": "Allow",
-                      "priority": 100,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "AllowGatewayManagerInBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "GatewayManager",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "*",
-                      "access": "Allow",
-                      "priority": 110,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "AllowLoadBalancerInBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "AzureLoadBalancer",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "*",
-                      "access": "Allow",
-                      "priority": 120,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "DenyAllInBound",
-                    "properties": {
-                      "protocol": "*",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationPortRange": "*",
-                      "destinationAddressPrefix": "*",
-                      "access": "Deny",
-                      "priority": 1000,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "AllowSshRdpOutBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationPortRanges": ["22", "3389"],
-                      "destinationAddressPrefix": "VirtualNetwork",
-                      "access": "Allow",
-                      "priority": 100,
-                      "direction": "Outbound"
-                    }
-                  },
-                  {
-                    "name": "AllowAzureCloudCommunicationOutBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "AzureCloud",
-                      "access": "Allow",
-                      "priority": 110,
-                      "direction": "Outbound"
-                    }
-                  },
-                  {
-                    "name": "AllowGetSessionInformationOutBound",
-                    "properties": {
-                      "protocol": "*",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationAddressPrefix": "Internet",
-                      "destinationPortRanges": ["80", "443"],
-                      "access": "Allow",
-                      "priority": 130,
-                      "direction": "Outbound"
-                    }
-                  },
-                  {
-                    "name": "DenyAllOutBound",
-                    "properties": {
-                      "protocol": "*",
-                      "sourcePortRange": "*",
-                      "destinationPortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationAddressPrefix": "*",
-                      "access": "Deny",
-                      "priority": 1000,
-                      "direction": "Outbound"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "type": "Microsoft.Network/networkSecurityGroups",
-              "apiVersion": "2022-07-01",
-              "name": "[variables('nsgNameOutbound')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "securityRules": [
-                  {
-                    "name": "AllowHttpsInBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "Internet",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "*",
-                      "access": "Allow",
-                      "priority": 100,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "AllowGatewayManagerInBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "GatewayManager",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "*",
-                      "access": "Allow",
-                      "priority": 110,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "AllowLoadBalancerInBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "AzureLoadBalancer",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "*",
-                      "access": "Allow",
-                      "priority": 120,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "DenyAllInBound",
-                    "properties": {
-                      "protocol": "*",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationPortRange": "*",
-                      "destinationAddressPrefix": "*",
-                      "access": "Deny",
-                      "priority": 1000,
-                      "direction": "Inbound"
-                    }
-                  },
-                  {
-                    "name": "AllowSshRdpOutBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationPortRanges": ["22", "3389"],
-                      "destinationAddressPrefix": "VirtualNetwork",
-                      "access": "Allow",
-                      "priority": 100,
-                      "direction": "Outbound"
-                    }
-                  },
-                  {
-                    "name": "AllowAzureCloudCommunicationOutBound",
-                    "properties": {
-                      "protocol": "Tcp",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationPortRange": "443",
-                      "destinationAddressPrefix": "AzureCloud",
-                      "access": "Allow",
-                      "priority": 110,
-                      "direction": "Outbound"
-                    }
-                  },
-                  {
-                    "name": "AllowGetSessionInformationOutBound",
-                    "properties": {
-                      "protocol": "*",
-                      "sourcePortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationAddressPrefix": "Internet",
-                      "destinationPortRanges": ["80", "443"],
-                      "access": "Allow",
-                      "priority": 130,
-                      "direction": "Outbound"
-                    }
-                  },
-                  {
-                    "name": "DenyAllOutBound",
-                    "properties": {
-                      "protocol": "*",
-                      "sourcePortRange": "*",
-                      "destinationPortRange": "*",
-                      "sourceAddressPrefix": "*",
-                      "destinationAddressPrefix": "*",
-                      "access": "Deny",
-                      "priority": 1000,
-                      "direction": "Outbound"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "type": "Microsoft.Network/virtualNetworks/subnets",
-              "apiVersion": "2022-07-01",
-              "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('inboundSubnet'))]",
-              "properties": {
-                "addressPrefix": "[parameters('inboundAddressPrefix')]",
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
-                },
-                "delegations": [
-                  {
-                    "name": "Microsoft.Network.dnsResolvers",
-                    "properties": {
-                      "serviceName": "Microsoft.Network/dnsResolvers"
-                    }
-                  }
-                ]
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Network/virtualNetworks/subnets",
-              "apiVersion": "2022-07-01",
-              "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('outboundSubnet'))]",
-              "properties": {
-                "addressPrefix": "[parameters('outboundAddressPrefix')]",
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]"
-                },
-                "delegations": [
-                  {
-                    "name": "Microsoft.Network.dnsResolvers",
-                    "properties": {
-                      "serviceName": "Microsoft.Network/dnsResolvers"
-                    }
-                  }
-                ]
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('resolverVnetName'), parameters('inboundSubnet'))]"
-              ]
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "allowedValues": [
+                "australiaeast",
+                "uksouth",
+                "northeurope",
+                "southcentralus",
+                "westus3",
+                "eastus",
+                "northcentralus",
+                "westcentralus",
+                "eastus2",
+                "westeurope",
+                "centralus",
+                "canadacentral",
+                "brazilsouth",
+                "francecentral",
+                "swedencentral",
+                "switzerlandnorth",
+                "eastasia",
+                "southeastasia",
+                "japaneast",
+                "koreacentral",
+                "southafricanorth",
+                "centralindia",
+                "westus",
+                "canadaeast",
+                "qatarcentral",
+                "uaenorth",
+                "australiasoutheast",
+                "polandcentral",
+                "spaincentral",
+                "italynorth"
+            ],
+            "metadata": {
+                "description": "Azure region for DNS private resolver and virtual network. Azure DNS Private Resolver available in specific region, refer the documentation to select the supported region for this deployment. For more information https://docs.microsoft.com/azure/dns/dns-private-resolver-overview#regional-availability"
             }
-          ]
+        },
+        "inboundSubnet": {
+            "type": "string",
+            "defaultValue": "snet-dnspr-in",
+            "metadata": {
+                "description": "Name of the subnet that will be used for private resolver inbound endpoint"
+            }
+        },
+        "inboundAddressPrefix": {
+            "type": "string",
+            "defaultValue": "10.100.9.0/28",
+            "metadata": {
+                "description": "The inbound endpoint subnet address space"
+            }
+        },
+        "outboundSubnet": {
+            "type": "string",
+            "defaultValue": "snet-dnspr-out",
+            "metadata": {
+                "description": "Name of the subnet that will be used for private resolver outbound endpoint"
+            }
+        },
+        "outboundAddressPrefix": {
+            "type": "string",
+            "defaultValue": "10.100.9.16/28",
+            "metadata": {
+                "description": "The outbound endpoint subnet address space"
+            }
+        },
+        "resolvervnetlink": {
+            "type": "string",
+            "defaultValue": "dnspr-vnetlink",
+            "metadata": {
+                "description": "Name of the vnet link that links outbound endpoint with forwarding rule set"
+            }
+        },
+        "forwardingRulesetName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the forwarding ruleset"
+            }
+        },
+        "topLevelManagementGroupPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the intermediate root management group"
+            }
+        },
+        "resourceGroupOverride": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the resource group to deploy to"
+            }
+        },
+        "vnetRg": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Name of the resource group where the vnet is located"
+            }
+        },
+        "dnsResolverName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name for the DNS resolver"
+            }
         }
-      }
     },
-    {
-      "type": "Microsoft.Resources/resourceGroups",
-      "apiVersion": "2020-10-01",
-      "name": "[variables('rgName')]",
-      "location": "[parameters('location')]"
+    "variables": {
+        "resourceDeploymentName": "[format('dsnpr-{0}-deployment', parameters('location'))]",
+        "rgName": "[if(empty(parameters('resourceGroupOverride')), format('rg-{0}-dnspr-{1}', parameters('topLevelManagementGroupPrefix'), parameters('location')), parameters('resourceGroupOverride'))]",
+        "dnsForwardingRuleName": "[if(empty(parameters('forwardingRulesetName')), concat('dnsfrs-', parameters('topLevelManagementGroupPrefix'), '-', parameters('location')), parameters('forwardingRulesetName'))]"
     },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2019-10-01",
-      "name": "[variables('resourceDeploymentName')]",
-      "resourceGroup": "[variables('rgName')]",
-      "dependsOn": [
-        "[concat('Microsoft.Resources/resourceGroups/', variables('rgName'))]",
-        "[concat(variables('resourceDeploymentName'), '-corenetworking')]"
-      ],
-      "properties": {
-        "mode": "Incremental",
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "parameters": {
-          "location": {
-            "value": "[parameters('location')]"
-          },
-          "resolverVnetName": {
-            "value": "[parameters('resolverVnetName')]"
-          },
-          "vnetRgName": {
-            "value": "[parameters('vnetRg')]"
-          },
-          "dnsResolverName": {
-            "value": "[parameters('dnsResolverName')]"
-          },
-          "inboundSubnet": {
-            "value": "[parameters('inboundSubnet')]"
-          },
-          "outboundSubnet": {
-            "value": "[parameters('outboundSubnet')]"
-          },
-          "forwardingRulesetName": {
-            "value": "[variables('dnsForwardingRuleName')]"
-          },
-          "resolvervnetlink": {
-            "value": "[parameters('resolvervnetlink')]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "parameters": {
-            "location": {
-              "type": "string"
-            },
-            "resolverVnetName": {
-              "type": "string"
-            },
-            "vnetRgName": {
-              "type": "string"
-            },
-            "dnsResolverName": {
-              "type": "string"
-            },
-            "inboundSubnet": {
-              "type": "string"
-            },
-            "outboundSubnet": {
-              "type": "string"
-            },
-            "forwardingRulesetName": {
-              "type": "string"
-            },
-            "resolvervnetlink": {
-              "type": "string"
-            }
-          },
-          "variables": {},
-          "resources": [
-            {
-              "type": "Microsoft.Network/dnsResolvers",
-              "apiVersion": "2022-07-01",
-              "name": "[parameters('dnsResolverName')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "virtualNetwork": {
-                  "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
-                }
-              },
-              "dependsOn": []
-            },
-            {
-              "type": "Microsoft.Network/dnsResolvers/inboundEndpoints",
-              "apiVersion": "2022-07-01",
-              "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('inboundSubnet'))]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "privateIpAllocationMethod": "Dynamic",
-                    "subnet": {
-                      "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('inboundSubnet'))]"
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "name": "[concat(variables('resourceDeploymentName'), '-corenetworking')]",
+            "resourceGroup": "[parameters('vnetRg')]",
+            "dependsOn": [
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "resolverVnetName": {
+                        "value": "[parameters('resolverVnetName')]"
+                    },
+                    "dnsResolverName": {
+                        "value": "[parameters('dnsResolverName')]"
+                    },
+                    "inboundAddressPrefix": {
+                        "value": "[parameters('inboundAddressPrefix')]"
+                    },
+                    "inboundSubnet": {
+                        "value": "[parameters('inboundSubnet')]"
+                    },
+                    "outboundAddressPrefix": {
+                        "value": "[parameters('outboundAddressPrefix')]"
+                    },
+                    "outboundSubnet": {
+                        "value": "[parameters('outboundSubnet')]"
                     }
-                  }
-                ]
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Network/dnsResolvers/outboundEndpoints",
-              "apiVersion": "2022-07-01",
-              "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('outboundSubnet'))]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "subnet": {
-                  "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('outboundSubnet'))]"
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "location": {
+                            "type": "string"
+                        },
+                        "resolverVnetName": {
+                            "type": "string"
+                        },
+                        "dnsResolverName": {
+                            "type": "string"
+                        },
+                        "inboundAddressPrefix": {
+                            "type": "string"
+                        },
+                        "inboundSubnet": {
+                            "type": "string"
+                        },
+                        "outboundAddressPrefix": {
+                            "type": "string"
+                        },
+                        "outboundSubnet": {
+                            "type": "string"
+                        }
+                    },
+                    "variables": {
+                        "nsgNameInbound": "[format('{0}-inbound-nsg', parameters('dnsResolverName'))]",
+                        "nsgNameOutbound": "[format('{0}-outbound-nsg', parameters('dnsResolverName'))]"
+                    },
+                    "resources": [
+                        {
+                            "type": "Microsoft.Network/networkSecurityGroups",
+                            "apiVersion": "2022-07-01",
+                            "name": "[variables('nsgNameInbound')]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "securityRules": [
+                                    {
+                                        "name": "AllowHttpsInBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "Internet",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Allow",
+                                            "priority": 100,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowGatewayManagerInBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "GatewayManager",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Allow",
+                                            "priority": 110,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowLoadBalancerInBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "AzureLoadBalancer",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Allow",
+                                            "priority": 120,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "DenyAllInBound",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationPortRange": "*",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Deny",
+                                            "priority": 1000,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowSshRdpOutBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationPortRanges": [
+                                                "22",
+                                                "3389"
+                                            ],
+                                            "destinationAddressPrefix": "VirtualNetwork",
+                                            "access": "Allow",
+                                            "priority": 100,
+                                            "direction": "Outbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowAzureCloudCommunicationOutBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "AzureCloud",
+                                            "access": "Allow",
+                                            "priority": 110,
+                                            "direction": "Outbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowGetSessionInformationOutBound",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "Internet",
+                                            "destinationPortRanges": [
+                                                "80",
+                                                "443"
+                                            ],
+                                            "access": "Allow",
+                                            "priority": 130,
+                                            "direction": "Outbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "DenyAllOutBound",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Deny",
+                                            "priority": 1000,
+                                            "direction": "Outbound"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Network/networkSecurityGroups",
+                            "apiVersion": "2022-07-01",
+                            "name": "[variables('nsgNameOutbound')]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "securityRules": [
+                                    {
+                                        "name": "AllowHttpsInBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "Internet",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Allow",
+                                            "priority": 100,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowGatewayManagerInBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "GatewayManager",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Allow",
+                                            "priority": 110,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowLoadBalancerInBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "AzureLoadBalancer",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Allow",
+                                            "priority": 120,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "DenyAllInBound",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationPortRange": "*",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Deny",
+                                            "priority": 1000,
+                                            "direction": "Inbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowSshRdpOutBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationPortRanges": [
+                                                "22",
+                                                "3389"
+                                            ],
+                                            "destinationAddressPrefix": "VirtualNetwork",
+                                            "access": "Allow",
+                                            "priority": 100,
+                                            "direction": "Outbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowAzureCloudCommunicationOutBound",
+                                        "properties": {
+                                            "protocol": "Tcp",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationPortRange": "443",
+                                            "destinationAddressPrefix": "AzureCloud",
+                                            "access": "Allow",
+                                            "priority": 110,
+                                            "direction": "Outbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "AllowGetSessionInformationOutBound",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "Internet",
+                                            "destinationPortRanges": [
+                                                "80",
+                                                "443"
+                                            ],
+                                            "access": "Allow",
+                                            "priority": 130,
+                                            "direction": "Outbound"
+                                        }
+                                    },
+                                    {
+                                        "name": "DenyAllOutBound",
+                                        "properties": {
+                                            "protocol": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationPortRange": "*",
+                                            "sourceAddressPrefix": "*",
+                                            "destinationAddressPrefix": "*",
+                                            "access": "Deny",
+                                            "priority": 1000,
+                                            "direction": "Outbound"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Network/virtualNetworks/subnets",
+                            "apiVersion": "2022-07-01",
+                            "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('inboundSubnet'))]",
+                            "properties": {
+                                "addressPrefix": "[parameters('inboundAddressPrefix')]",
+                                "networkSecurityGroup": {
+                                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
+                                },
+                                "delegations": [
+                                    {
+                                        "name": "Microsoft.Network.dnsResolvers",
+                                        "properties": {
+                                            "serviceName": "Microsoft.Network/dnsResolvers"
+                                        }
+                                    }
+                                ]
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameInbound'))]"
+                            ]
+                        },
+                        {
+                            "type": "Microsoft.Network/virtualNetworks/subnets",
+                            "apiVersion": "2022-07-01",
+                            "name": "[format('{0}/{1}', parameters('resolverVnetName'), parameters('outboundSubnet'))]",
+                            "properties": {
+                                "addressPrefix": "[parameters('outboundAddressPrefix')]",
+                                "networkSecurityGroup": {
+                                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]"
+                                },
+                                "delegations": [
+                                    {
+                                        "name": "Microsoft.Network.dnsResolvers",
+                                        "properties": {
+                                            "serviceName": "Microsoft.Network/dnsResolvers"
+                                        }
+                                    }
+                                ]
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgNameOutbound'))]",
+                                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('resolverVnetName'), parameters('inboundSubnet'))]"
+                            ]
+                        }
+                    ]
                 }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Network/dnsForwardingRulesets",
-              "apiVersion": "2022-07-01",
-              "name": "[parameters('forwardingRulesetName')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "dnsResolverOutboundEndpoints": [
-                  {
-                    "id": "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
-                  }
-                ]
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
-              ]
-            },
-            {
-              "type": "Microsoft.Network/dnsForwardingRulesets/virtualNetworkLinks",
-              "apiVersion": "2022-07-01",
-              "name": "[format('{0}/{1}', parameters('forwardingRulesetName'), parameters('resolvervnetlink'))]",
-              "properties": {
-                "virtualNetwork": {
-                  "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Network/dnsForwardingRulesets', parameters('forwardingRulesetName'))]"
-              ]
             }
-          ]
+        },
+        {
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2020-10-01",
+            "name": "[variables('rgName')]",
+            "location": "[parameters('location')]"
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "name": "[variables('resourceDeploymentName')]",
+            "resourceGroup": "[variables('rgName')]",
+            "dependsOn": [
+                "[concat('Microsoft.Resources/resourceGroups/', variables('rgName'))]",
+                "[concat(variables('resourceDeploymentName'), '-corenetworking')]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "resolverVnetName": {
+                        "value": "[parameters('resolverVnetName')]"
+                    },
+                    "vnetRgName": {
+                        "value": "[parameters('vnetRg')]"
+                    },
+                    "dnsResolverName": {
+                        "value": "[parameters('dnsResolverName')]"
+                    },
+                    "inboundSubnet": {
+                        "value": "[parameters('inboundSubnet')]"
+                    },
+                    "outboundSubnet": {
+                        "value": "[parameters('outboundSubnet')]"
+                    },
+                    "forwardingRulesetName": {
+                        "value": "[variables('dnsForwardingRuleName')]"
+                    },
+                    "resolvervnetlink": {
+                        "value": "[parameters('resolvervnetlink')]"
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "location": {
+                            "type": "string"
+                        },
+                        "resolverVnetName": {
+                            "type": "string"
+                        },
+                        "vnetRgName": {
+                            "type": "string"
+                        },
+                        "dnsResolverName": {
+                            "type": "string"
+                        },
+                        "inboundSubnet": {
+                            "type": "string"
+                        },
+                        "outboundSubnet": {
+                            "type": "string"
+                        },
+                        "forwardingRulesetName": {
+                            "type": "string"
+                        },
+                        "resolvervnetlink": {
+                            "type": "string"
+                        }
+                    },
+                    "variables": {
+                    },
+                    "resources": [
+                        {
+                            "type": "Microsoft.Network/dnsResolvers",
+                            "apiVersion": "2022-07-01",
+                            "name": "[parameters('dnsResolverName')]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "virtualNetwork": {
+                                    "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
+                                }
+                            },
+                            "dependsOn": [
+                            ]
+                        },
+                        {
+                        "type": "Microsoft.Network/dnsResolvers/inboundEndpoints",
+                        "apiVersion": "2022-07-01",
+                        "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('inboundSubnet'))]",
+                        "location": "[parameters('location')]",
+                        "properties": {
+                            "ipConfigurations": [
+                            {
+                                "privateIpAllocationMethod": "Dynamic",
+                                "subnet": {
+                                    "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('inboundSubnet'))]"
+                                }
+                            }
+                            ]
+                        },
+                        "dependsOn": [
+                            "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
+                        ]
+                        },
+                        {
+                            "type": "Microsoft.Network/dnsResolvers/outboundEndpoints",
+                            "apiVersion": "2022-07-01",
+                            "name": "[format('{0}/{1}', parameters('dnsResolverName'), parameters('outboundSubnet'))]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "subnet": {
+                                    "id": "[format('{0}/subnets/{1}', concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName')), parameters('outboundSubnet'))]"
+                                }
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/dnsResolvers', parameters('dnsResolverName'))]"
+                            ]
+                        },
+                        {
+                            "type": "Microsoft.Network/dnsForwardingRulesets",
+                            "apiVersion": "2022-07-01",
+                            "name": "[parameters('forwardingRulesetName')]",
+                            "location": "[parameters('location')]",
+                            "properties": {
+                                "dnsResolverOutboundEndpoints": [
+                                    {
+                                        "id": "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
+                                    }
+                                ]
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/dnsResolvers/outboundEndpoints', parameters('dnsResolverName'), parameters('outboundSubnet'))]"
+                            ]
+                        },
+                        {
+                            "type": "Microsoft.Network/dnsForwardingRulesets/virtualNetworkLinks",
+                            "apiVersion": "2022-07-01",
+                            "name": "[format('{0}/{1}', parameters('forwardingRulesetName'), parameters('resolvervnetlink'))]",
+                            "properties": {
+                                "virtualNetwork": {
+                                    "id": "[concat(subscription().id,'/resourceGroups/',parameters('vnetRgName'), '/providers/','Microsoft.Network/virtualNetworks/', parameters('resolverVNETName'))]"
+                                }
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Network/dnsForwardingRulesets', parameters('forwardingRulesetName'))]"
+                            ]
+                        }
+                    ]
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Private DNS Resolver cannot be deployed using the accelerator through the Portal Experience in Spain Central and Italy North regions, this service is already available on those regions.

## This PR fixes/adds/changes/removes

1. Fix the deployment for Private DNS Resolver in Spain Central and Italy North regions

### Breaking Changes

N/A

## Testing Evidence

Only added more regions to `allowedValues` array, region availability per product is [here](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/table)

### Testing URLs

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoselcaguilar%2FEnterprise-Scale%2Fjoselcaguilar%2Fpdns-resolver-spc%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoselcaguilar%2FEnterprise-Scale%2Fjoselcaguilar%2Fpdns-resolver-spc%2FeslzArm%2Feslz-portal.json)

#### Azure US Gov (Fairfax)
[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoselcaguilar%2FEnterprise-Scale%2Fjoselcaguilar%2Fpdns-resolver-spc%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fjoselcaguilar%2FEnterprise-Scale%2Fjoselcaguilar%2Fpdns-resolver-spc%2FeslzArm%2Ffairfaxeslz-portal.json)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Enterprise-Scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/Enterprise-Scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Enterprise-Scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)
