### PR TITLE
fix: replace null() with createArray() for empty parameter handling - Service Health Policy

### DIFF
--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -2514,7 +2514,7 @@
                         "value": "[parameters('userAssignedManagedIdentityName')]"
                     },
                     "ALZWebhookServiceUri": {
-                        "value": "[if(empty(parameters('ambaAgServiceHook')), null(), array(parameters('ambaAgServiceHook')))]"
+                        "value": "[if(empty(parameters('ambaAgServiceHook')), createArray(), array(parameters('ambaAgServiceHook')))]"
                     },
                     "ALZArmRoleId": {
                         "value": "[variables('ambaArmRoleConverted')]"
@@ -2526,7 +2526,7 @@
                         "value": "[deployment().location]"
                     },
                     "ALZMonitorActionGroupEmail": {
-                        "value": "[if(empty(parameters('ambaAgEmailContact')), null(), array(parameters('ambaAgEmailContact')))]"
+                        "value": "[if(empty(parameters('ambaAgEmailContact')), createArray(), array(parameters('ambaAgEmailContact')))]"
                     },
                     "managementSubscriptionId": {
                         "value": "[parameters('managementSubscriptionId')]"
@@ -2617,7 +2617,7 @@
                         "value": "[parameters('userAssignedManagedIdentityName')]"
                     },
                     "ALZWebhookServiceUri": {
-                        "value": "[if(empty(parameters('ambaAgServiceHook')), null(), array(parameters('ambaAgServiceHook')))]"
+                        "value": "[if(empty(parameters('ambaAgServiceHook')), createArray(), array(parameters('ambaAgServiceHook')))]"
                     },
                     "ALZArmRoleId": {
                         "value": "[variables('ambaArmRoleConverted')]"
@@ -2629,7 +2629,7 @@
                         "value": "[deployment().location]"
                     },
                     "ALZMonitorActionGroupEmail": {
-                        "value": "[if(empty(parameters('ambaAgEmailContact')), null(), array(parameters('ambaAgEmailContact')))]"
+                        "value": "[if(empty(parameters('ambaAgEmailContact')), createArray(), array(parameters('ambaAgEmailContact')))]"
                     },
                     "managementSubscriptionId": {
                         "value": "[parameters('singlePlatformSubscriptionId')]"
@@ -3129,10 +3129,10 @@
                         "value": "[parameters('enterpriseScaleCompanyPrefix')]"
                     },
                     "actionGroupResourcesEmail": {
-                        "value": "[if(empty(parameters('ambaAgEmailContact')), null(), array(parameters('ambaAgEmailContact')))]"
+                        "value": "[if(empty(parameters('ambaAgEmailContact')), createArray(), array(parameters('ambaAgEmailContact')))]"
                     },
                     "actionGroupResourcesWebhook": {
-                        "value": "[if(empty(parameters('ambaAgServiceHook')), null(), array(parameters('ambaAgServiceHook')))]"
+                        "value": "[if(empty(parameters('ambaAgServiceHook')), createArray(), array(parameters('ambaAgServiceHook')))]"
                     },
                     "actionGroupRoleIds": {
                         "value": "[variables('ambaArmRoleConverted')]"


### PR DESCRIPTION
This pull request updates how empty parameter values are handled in the `eslzArm.json` ARM template. Instead of returning `null()` for empty parameters, the template now returns an empty array using `createArray()`. This change ensures consistent data types are passed to downstream resources, which can help prevent errors related to unexpected `null` values.

Parameter handling improvements:

* Changed the handling of empty `ambaAgServiceHook` parameters to return an empty array (`createArray()`) instead of `null()` in multiple locations, including `ALZWebhookServiceUri` and `actionGroupResourcesWebhook`. [[1]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L2517-R2517) [[2]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L2620-R2620) [[3]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L3132-R3135)
* Changed the handling of empty `ambaAgEmailContact` parameters to return an empty array (`createArray()`) instead of `null()` in multiple locations, including `ALZMonitorActionGroupEmail` and `actionGroupResourcesEmail`. [[1]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L2529-R2529) [[2]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L2632-R2632) [[3]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970L3132-R3135)