### PR TITLE
Updated the what's new step in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,4 +39,3 @@ The below URLs can be updated where the placeholders are, look for `{YOUR GITHUB
 - [ ] Performed testing and provided evidence.
 - [ ] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
 - [ ] Updated relevant and associated documentation.
-- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located: `/docs/wiki/whats-new.md`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,3 +39,4 @@ The below URLs can be updated where the placeholders are, look for `{YOUR GITHUB
 - [ ] Performed testing and provided evidence.
 - [ ] Ensured [contribution guidance](https://github.com/Azure/Enterprise-Scale/wiki/ALZ-Contribution-Guide) is followed.
 - [ ] Updated relevant and associated documentation.
+- [ ] Created a pull request to updated the ["What's New?"](https://github.com/Azure/Azure-Landing-Zones/blob/main/docs/content/whats-new/_index.md) wiki page.


### PR DESCRIPTION
The page says:
https://github.com/Azure/Enterprise-Scale/blob/main/docs/wiki/Whats-new.md

> **Important:** We are migrating all documentation to the central Azure landing zone repository (https://azure.github.io/Azure-Landing-Zones/). As a result this content is now available here: https://azure.github.io/Azure-Landing-Zones/whats-new/

Sounds like its not expected to update it when you make a PR here anymore? It doesn't give you a link to the source file.

Happy to close if you want something else