### PR TITLE
feat: add new local MG and ALDO policy assignment

### DIFF
--- a/eslzArm/eslz-portal.json
+++ b/eslzArm/eslz-portal.json
@@ -6166,6 +6166,30 @@
                                         ]
                                     },
                                     "visible": true
+                                },
+                                {
+                                    "name": "enforceAldoServices",
+                                    "type": "Microsoft.Common.OptionsGroup",
+                                    "label": "Audit Azure services supported in Azure Local disconnected operations (assigned to the Local landing zone management group)",
+                                    "defaultValue": "Yes (recommended)",
+                                    "toolTip": "If 'Yes' is selected, Azure Policy will be assigned to the Local landing zone management group to audit the use of Azure services to those supported in Azure Local disconnected operations. Uses the built-in policy 'Audit resource types to Azure services supported in Azure Local disconnected operations' (dabf7c7f-5354-42de-a92a-8367f538dd71).",
+                                    "constraints": {
+                                        "allowedValues": [
+                                            {
+                                                "label": "Yes (recommended)",
+                                                "value": "Yes"
+                                            },
+                                            {
+                                                "label": "Audit only",
+                                                "value": "Audit"
+                                            },
+                                            {
+                                                "label": "No",
+                                                "value": "No"
+                                            }
+                                        ]
+                                    },
+                                    "visible": true
                                 }
                             ],
                             "visible": true
@@ -11005,6 +11029,7 @@
                 "auditPeDnsZones": "[steps('landingZones').corpSection.auditPeDnsZones]",
                 "auditAppGwWaf": "[steps('landingZones').lzSection.auditAppGwWaf]",
                 "enforceAcsb": "[steps('landingZones').lzSection.enforceAcsb]",
+                "enforceAldoServices": "[steps('landingZones').lzSection.enforceAldoServices]",
                 "enableDecommissioned": "[steps('decommissionedSandboxZones').decommSection.enableDecommissioned]",
                 "enableSandbox": "[steps('decommissionedSandboxZones').sandboxSection.enableSandbox]",
                 "enableWsCMKInitiatives": "[steps('workloadspecific').wlcCMK.enableWsCMKInitiatives]",

--- a/eslzArm/eslzArm.json
+++ b/eslzArm/eslzArm.json
@@ -1192,6 +1192,18 @@
                 "No"
             ]
         },
+        "enforceAldoServices": {
+            "type": "string",
+            "defaultValue": "Yes",
+            "allowedValues": [
+                "Yes",
+                "Audit",
+                "No"
+            ],
+            "metadata": {
+                "description": "Audit the use of Azure services to those supported in Azure Local disconnected operations. Assigned to the Local landing zone management group."
+            }
+        },
         "delayCount": {
             "type": "int",
             "defaultValue": 55,
@@ -1841,6 +1853,7 @@
             "lzs": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'landingzones')]",
             "corp": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'corp')]",
             "online": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'online')]",
+            "local": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'local')]",
             "decommissioned": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'decommissioned')]",
             "sandboxes": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'sandboxes')]"
         },
@@ -1850,6 +1863,7 @@
             "lzs": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'landingzones')]",
             "corp": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'corp')]",
             "online": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'online')]",
+            "local": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'local')]",
             "decommissioned": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'decommissioned')]",
             "sandboxes": "[concat(parameters('enterpriseScaleCompanyPrefix'), '-', 'sandboxes')]"
         },
@@ -1876,6 +1890,7 @@
             "lzsManagementGroup": "[tenantResourceId('Microsoft.Management/managementGroups/', variables('mgmtGroups').lzs)]",
             "corpManagementGroup": "[tenantResourceId('Microsoft.Management/managementGroups/', variables('mgmtGroups').corp)]",
             "onlineManagementGroup": "[tenantResourceId('Microsoft.Management/managementGroups/', variables('mgmtGroups').online)]",
+            "localManagementGroup": "[tenantResourceId('Microsoft.Management/managementGroups/', variables('mgmtGroups').local)]",
             "decommissionedManagementGroup": "[tenantResourceId('Microsoft.Management/managementGroups/', variables('mgmtGroups').decommissioned)]",
             "sandboxManagementGroup": "[tenantResourceId('Microsoft.Management/managementGroups/', variables('mgmtGroups').sandboxes)]"
         },
@@ -1943,6 +1958,7 @@
             "auditPeDnsZonesPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/AUDIT-PeDnsZonesPolicyAssignment.json')]",
             "auditAppGwWafPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/AUDIT-AppGwWafPolicyAssignment.json')]",
             "enforceAcsbPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/ENFORCE-AcsbPolicyAssignment.json')]",
+            "enforceAldoServicesPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/ENFORCE-ALDO-ServicesPolicyAssignment.json')]",
             "subnetNsgPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/DENY-SubnetWithoutNsgPolicyAssignment.json')]",
             "sqlAuditPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/DINE-SQLAuditingPolicyAssignment.json')]",
             "sqlEncryptionPolicyAssignment": "[uri(deployment().properties.templateLink.uri, 'managementGroupTemplates/policyAssignments/DINE-SQLEncryptionPolicyAssignment.json')]",
@@ -2083,6 +2099,7 @@
             "auditPeDnsZonesPolicyDeploymentName": "[take(concat('alz-AuditPeDnsZones', variables('deploymentSuffix')), 64)]",
             "auditAppGwWafPolicyDeploymentName": "[take(concat('alz-AppGwWaf', variables('deploymentSuffix')), 64)]",
             "enforceAcsbPolicyDeploymentName": "[take(concat('alz-Acsb', variables('deploymentSuffix')), 64)]",
+            "enforceAldoServicesPolicyDeploymentName": "[take(concat('alz-AldoSvc', variables('deploymentSuffix')), 64)]",
             "subnetNsgPolicyDeploymentName": "[take(concat('alz-SubnetNsg', variables('deploymentSuffix')), 64)]",
             "subnetNsgIdentityPolicyDeploymentName": "[take(concat('alz-SubnetNsgIdentity', variables('deploymentSuffix')), 64)]",
             "sqlAuditPolicyDeploymentName": "[take(concat('alz-SqlAudit', variables('deploymentSuffix')), 64)]",
@@ -8251,6 +8268,30 @@
                     },
                     "enforcementMode": {
                         "value": "[if(equals(parameters('enforceACSB'), 'Yes'), 'Default', 'DoNotEnforce')]"
+                    }
+                }
+            }
+        },
+        {
+            // Assigning policy to audit Azure services supported in Azure Local disconnected operations to the Local landing zones management group if condition is true
+            "condition": "[or(equals(parameters('enforceAldoServices'), 'Yes'), equals(parameters('enforceAldoServices'), 'Audit'))]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2024-11-01",
+            "name": "[variables('deploymentNames').enforceAldoServicesPolicyDeploymentName]",
+            "scope": "[variables('scopes').localManagementGroup]",
+            "location": "[deployment().location]",
+            "dependsOn": [
+                "alz-prerequisites"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "contentVersion": "1.0.0.0",
+                    "uri": "[variables('deploymentUris').enforceAldoServicesPolicyAssignment]"
+                },
+                "parameters": {
+                    "enforcementMode": {
+                        "value": "[if(equals(parameters('enforceAldoServices'), 'Yes'), 'Default', 'DoNotEnforce')]"
                     }
                 }
             }

--- a/eslzArm/eslzArm.terraform-sync.param.json
+++ b/eslzArm/eslzArm.terraform-sync.param.json
@@ -385,6 +385,9 @@
     "enforceAcsb": {
       "value": "Yes"
     },
+    "enforceAldoServices": {
+      "value": "Yes"
+    },
     "enforceBackup": {
       "value": "Yes"
     },

--- a/eslzArm/eslzArm.test.param.hns.json
+++ b/eslzArm/eslzArm.test.param.hns.json
@@ -495,6 +495,9 @@
         "enforceAcsb": {
             "value": "Yes"
         },
+        "enforceAldoServices": {
+            "value": "Yes"
+        },
         "delayCount": {
             "value": 45
         },

--- a/eslzArm/eslzArm.test.param.json
+++ b/eslzArm/eslzArm.test.param.json
@@ -302,6 +302,9 @@
         "enforceAcsb": {
             "value": "Yes"
         },
+        "enforceAldoServices": {
+            "value": "Yes"
+        },
         "delayCount": {
             "value": 35
         }

--- a/eslzArm/eslzArm.test.param.std.json
+++ b/eslzArm/eslzArm.test.param.std.json
@@ -359,6 +359,9 @@
         "enforceAcsb": {
             "value": "Yes"
         },
+        "enforceAldoServices": {
+            "value": "Yes"
+        },
         "delayCount": {
             "value": 45
         },

--- a/eslzArm/eslzArm.test.param.vwan.json
+++ b/eslzArm/eslzArm.test.param.vwan.json
@@ -421,6 +421,9 @@
         "enforceAcsb": {
             "value": "Yes"
         },
+        "enforceAldoServices": {
+            "value": "Yes"
+        },
         "delayCount": {
             "value": 45
         },

--- a/eslzArm/managementGroupTemplates/mgmtGroupStructure/mgmtGroups.json
+++ b/eslzArm/managementGroupTemplates/mgmtGroupStructure/mgmtGroups.json
@@ -24,7 +24,8 @@
             "type": "array",
             "defaultValue": [
                 "online",
-                "corp"
+                "corp",
+                "local"
             ],
             "metadata": {
                 "description": "These are the landing zone management groups."

--- a/eslzArm/managementGroupTemplates/mgmtGroupStructure/mgmtGroupsLite.json
+++ b/eslzArm/managementGroupTemplates/mgmtGroupStructure/mgmtGroupsLite.json
@@ -12,7 +12,8 @@
             "type": "array",
             "defaultValue": [
                 "online",
-                "corp"
+                "corp",
+                "local"
             ],
             "metadata": {
                 "description": "These are the landing zone management groups."

--- a/eslzArm/managementGroupTemplates/policyAssignments/ENFORCE-ALDO-ServicesPolicyAssignment.json
+++ b/eslzArm/managementGroupTemplates/policyAssignments/ENFORCE-ALDO-ServicesPolicyAssignment.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "enforcementMode": {
+            "type": "string",
+            "allowedValues": [
+                "Default",
+                "DoNotEnforce"
+            ],
+            "defaultValue": "Default"
+        },
+        "includeMatchedServices": {
+            "type": "bool",
+            "defaultValue": true
+        },
+        "nonComplianceMessagePlaceholder": {
+            "type": "string",
+            "defaultValue": "{enforcementMode}"
+        }
+    },
+    "variables": {
+        "policyDefinitions": {
+            "enforceAldoServices": "/providers/Microsoft.Authorization/policyDefinitions/dabf7c7f-5354-42de-a92a-8367f538dd71",
+            "policyVersion": "1.*.*-preview"
+        },
+        "policyAssignmentNames": {
+            "enforceAldoServices": "Enforce-ALDO-Services",
+            "description": "Audit the use of Azure services to those supported in Azure Local disconnected operations.",
+            "displayName": "Audit resource types to Azure services supported in Azure Local disconnected operations"
+        },
+        "nonComplianceMessage": {
+            "message": "Resource is not available on Azure Local disconnected operations cluster."
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Authorization/policyAssignments",
+            "apiVersion": "2024-04-01",
+            "name": "[variables('policyAssignmentNames').enforceAldoServices]",
+            "properties": {
+                "description": "[variables('policyAssignmentNames').description]",
+                "displayName": "[variables('policyAssignmentNames').displayName]",
+                "policyDefinitionId": "[variables('policyDefinitions').enforceAldoServices]",
+                "definitionVersion": "[variables('policyDefinitions').policyVersion]",
+                "enforcementMode": "[parameters('enforcementMode')]",
+                "nonComplianceMessages": [
+                    {
+                        "message": "[variables('nonComplianceMessage').message]"
+                    }
+                ],
+                "parameters": {
+                    "includeMatchedServices": {
+                        "value": "[parameters('includeMatchedServices')]"
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}


### PR DESCRIPTION
This pull request introduces a new policy control to audit and optionally enforce the use of Azure services that are supported in Azure Local disconnected operations, focusing on the "Local" landing zone management group. The changes add a new parameter and deployment logic to support this policy, update the management group structure, and include a new policy assignment template.

**Policy enforcement for Azure Local disconnected operations:**

* Added a new `enforceAldoServices` parameter to `eslzArm.json` and all related parameter files, allowing users to choose whether to enforce, audit, or disable auditing of Azure services supported in Azure Local disconnected operations. [[1]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R1195-R1206) [[2]](diffhunk://#diff-bbf68d99ce8afe621f4f96f7dd4da4f4c5f59501f55c8d361f8abc9fa0671d48R388-R390) [[3]](diffhunk://#diff-ce401cc988868ff914606322560f7c8215ef1c60703fcfb56caa58cd78faa193R498-R500) [[4]](diffhunk://#diff-bfccc174e492b9ae29dc293e9a1b727933de33014038a3734359449b540ee7d6R305-R307) [[5]](diffhunk://#diff-dd5a61c1bcf90eecd500f8792f0d4c480c11c26f0b6655d1bb64173d1e86f4b4R362-R364) [[6]](diffhunk://#diff-2793546efbbfece2b6b802f65f2afc2e20435b207fbadb5df38b2177549e70efR424-R426)
* Updated the portal configuration (`eslz-portal.json`) to expose the new policy option in the UI, including labels, tooltips, and allowed values. [[1]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR6169-R6192) [[2]](diffhunk://#diff-64ee2c93f8e558836414defcc76ec71758fc1bb50f574e169d6f5750e904a64fR11032)

**Management group structure and scoping:**

* Added the "local" management group to the management group structure and variables, ensuring it is recognized and available for policy assignment and scoping. [[1]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R1856) [[2]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R1866) [[3]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R1893) [[4]](diffhunk://#diff-247f49b77708d081b7a83a5113983554e0da7a05d4248b698cb04fd6839c1a55L27-R28) [[5]](diffhunk://#diff-e1b88acc714d5c2e6412f00fe1506a5f425cf6008c642886ae9489fd2b109e87L15-R16)

**Policy deployment logic and templates:**

* Integrated deployment logic in `eslzArm.json` to assign the new policy to the Local management group when the parameter is set to "Yes" or "Audit", including URI references and deployment name variables. [[1]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R1961) [[2]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R2102) [[3]](diffhunk://#diff-58a2a55a8192e9f53dbbf24829de525fd2dfe86dd56d9ea5fe4ce54f71eac970R8275-R8298)
* Added a new policy assignment template file, `ENFORCE-ALDO-ServicesPolicyAssignment.json`, which assigns the built-in policy to audit Azure services in Local disconnected operations, with support for enforcement modes and non-compliance messaging.

#### Azure Public

[![Deploy To Azure](https://learn.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2Ffeat%2Fadd-local-mg%2FeslzArm%2FeslzArm.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2FEnterprise-Scale%2Ffeat%2Fadd-local-mg%2FeslzArm%2Feslz-portal.json)

#### Testing Evidence

<img width="1179" height="605" alt="image" src="https://github.com/user-attachments/assets/48bf931a-9ecd-4a2e-8b2b-8575c84fee9b" />

<img width="1108" height="543" alt="image" src="https://github.com/user-attachments/assets/45c29f60-1729-4731-bbc1-cd99eb1a2811" />

<img width="1387" height="459" alt="image" src="https://github.com/user-attachments/assets/dacd2707-7d58-4254-8bb3-1c817aa79656" />


