### PR TITLE
fix: exclude Deploy-SvcHealth-BuiltIn from base archetype to avoid AMBA Service Health duplication (#4210)

### DIFF
--- a/eslzArm/eslzArm.terraform-sync.param.json
+++ b/eslzArm/eslzArm.terraform-sync.param.json
@@ -248,7 +248,7 @@
       "value": "No"
     },
     "enableServiceHealthBuiltIn": {
-          "value": "Yes"
+          "value": "No"
         },
     "enableSqlAudit": {
       "value": "Yes"


### PR DESCRIPTION
## Overview

Fixes #4210

`Deploy-SvcHealth-BuiltIn` (assigned by the ALZ `root` archetype) and AMBA's `Deploy-AMBA-Res-SvcHlth` initiative member `ALZ_SHA_BuiltIn` both reference the **same** built-in Service Health policy definition (`98903777-a9f6-47f5-90a9-acaf62ab01a8`). When both ALZ and AMBA are deployed to the same management-group hierarchy, each independently runs its own DINE remediation, producing **duplicate action groups and duplicate Service Health alert rules** (in `rg-serviceHealthAlert` and `rg-amba-monitoring-001`).

The Enterprise-Scale ARM/portal path already avoids this via the mutually-exclusive `enableServiceHealth` condition. However, the ALZ Library (Terraform) path loses that protection because `platform/alz` and `platform/amba` are generated from independent sources, so both assignments land together.

## Change

Set `enableServiceHealthBuiltIn` to `"No"` in `eslzArm/eslzArm.terraform-sync.param.json`. This excludes `Deploy-SvcHealth-BuiltIn` from the generated ALZ `root` archetype in the [Azure Landing Zones Library](https://github.com/Azure/Azure-Landing-Zones-Library), so the built-in Service Health assignment no longer conflicts with AMBA's initiative.

```diff
     "enableServiceHealthBuiltIn": {
-          "value": "Yes"
+          "value": "No"
```

## Validation

- **Library sync simulation:** Ran `Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1` against this change — confirmed `Deploy-SvcHealth-BuiltIn` is removed from the generated `root.alz_archetype_definition.json`.
- **Live deployment repro (test tenant):**
  - **Pre-fix:** ALZ + AMBA assignments → **2 action groups + 2 identical Service Health alert rules** (duplication reproduced).
  - **Post-fix:** only AMBA's assignment remains → **1 action group + 1 alert rule**.

| | Action groups | Alert rules |
|---|---|---|
| Pre-fix (ALZ + AMBA) | 2 | 2 |
| Post-fix (AMBA only) | 1 | 1 |
<img width="1908" height="1022" alt="image" src="https://github.com/user-attachments/assets/d20d23cf-407d-45af-8d97-0f72b9ff90eb" />
<img width="1827" height="956" alt="image" src="https://github.com/user-attachments/assets/b48f3506-4806-431d-8fb5-56f08dc3826c" />
<img width="1728" height="192" alt="image" src="https://github.com/user-attachments/assets/b5dafeb7-18ad-4cdc-bf4e-9b1c69c2c014" />
<img width="1706" height="322" alt="image" src="https://github.com/user-attachments/assets/64eb83a1-4911-4774-abd1-eaef9a15b81d" />
<img width="1757" height="221" alt="image" src="https://github.com/user-attachments/assets/e97399e8-ee3c-4ef2-992c-f5d26d7713fc" />


Post fix validation
<img width="1883" height="943" alt="image" src="https://github.com/user-attachments/assets/40d9a8ef-eb60-4139-9413-61725a9bb0d7" />
<img width="1707" height="177" alt="image" src="https://github.com/user-attachments/assets/29647b83-58ef-4e77-b3fd-af0894109559" />
<img width="1717" height="204" alt="image" src="https://github.com/user-attachments/assets/991c00ff-fd2a-422b-85cc-8c29b7141fb1" />
<img width="1744" height="201" alt="image" src="https://github.com/user-attachments/assets/bb805ac4-50e4-45c1-9e7e-02f4026e1247" />
<img width="1730" height="184" alt="image" src="https://github.com/user-attachments/assets/7f053acc-c3d6-40d5-9090-98e56f2362c5" />




This removes the built-in Service Health assignment from the base archetype for **all** Library consumers, including non-AMBA deployments, which would lose the default Service Health alerting unless they re-enable it.
